### PR TITLE
Fixing yaml parsing bug with vault client setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.1] - 2024-01-24
+
+## Added
+
+- Additional error message when failing to create vault client
+
+## Fixed
+
+- Fixed loading for client key when using VAULT_CLIENT_KEY
+
 ## [0.1.0] - 2024-01-23
 
 ## Added

--- a/cmd/vaul7y/main.go
+++ b/cmd/vaul7y/main.go
@@ -47,6 +47,11 @@ func main() {
 	vaultClient, err := vault.New(func(v *vault.Vault) error {
 		return vault.Default(v, logger, cfg)
 	})
+	if err != nil {
+		fmt.Printf("Failed to start Vault client: %v\n", err)
+		os.Exit(1)
+	}
+
 	refreshIntervalDefault := time.Duration(cfg.VaultyRefreshRate) * time.Second
 	state := initializeState(vaultClient, cfg.VaultNamespace)
 	toggles := component.NewTogglesInfo()

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -20,7 +20,7 @@ type Config struct {
 	VaultToken        string `yaml:"vault_token"`
 	VaultCaCert       string `yaml:"vault_cacert"`
 	VaultClientCert   string `yaml:"vault_client_cert"`
-	VaultClientKey    string `yaml:"vault_client_Key"`
+	VaultClientKey    string `yaml:"vault_client_key"`
 	VaultyLogFile     string `yaml:"vaulty_log_file"`
 	VaultyLogLevel    string `yaml:"vaulty_log_level"`
 	VaultyRefreshRate int    `yaml:"vaulty_refresh_rate"`
@@ -79,7 +79,7 @@ func LoadConfig() Config {
 		config.VaultClientCert = vaultClientCert
 	}
 	if vaultClientKey := os.Getenv("VAULT_CLIENT_KEY"); vaultClientKey != "" {
-		config.VaultClientCert = vaultClientKey
+		config.VaultClientKey = vaultClientKey
 	}
 	if vaultyLogFile := os.Getenv("VAULTY_LOG_FILE"); vaultyLogFile != "" {
 		config.VaultyLogFile = vaultyLogFile


### PR DESCRIPTION
Fixed issue when setting client_key in yaml due to typo
Exiting the app if vault client can't start to prevent any misleading issues