### PR TITLE
Fallback method for mount listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.7] - 2024-04-24
+
+## Added
+
+-- Fallback method for mounts listing when user doesnt access to `sys/mounts`
+
 ## [0.1.5] - 2024-04-18
 
 ## Fixed

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -44,6 +44,12 @@ type MountConfigOutput struct {
 	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }
 
+type UiMountsResponse struct {
+	Data struct {
+		Secret map[string]*MountOutput `json:"secret"`
+	} `json:"data"`
+}
+
 type UserLockoutConfigOutput struct {
 	LockoutThreshold    uint  `json:"lockout_threshold,omitempty" structs:"lockout_threshold" mapstructure:"lockout_threshold"`
 	LockoutDuration     int   `json:"lockout_duration,omitempty" structs:"lockout_duration" mapstructure:"lockout_duration"`

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -110,7 +110,6 @@ func Default(v *Vault, log *zerolog.Logger, vaultyCfg config.Config) error {
 	health, err := client.Sys().Health()
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to connect to `v1/sys/health` ")
-		// client.NewRequest("GET", "v1/sys/health")
 	} else {
 		version = health.Version
 	}

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -110,6 +110,7 @@ func Default(v *Vault, log *zerolog.Logger, vaultyCfg config.Config) error {
 	health, err := client.Sys().Health()
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to connect to `v1/sys/health` ")
+		// client.NewRequest("GET", "v1/sys/health")
 	} else {
 		version = health.Version
 	}

--- a/internal/vault/mounts.go
+++ b/internal/vault/mounts.go
@@ -1,20 +1,20 @@
 package vault
 
 import (
+	"encoding/json"
 	"fmt"
-	"strings"
+	"io/ioutil"
 
 	"github.com/dkyanakiev/vaulty/internal/models"
 	"github.com/hashicorp/vault/api"
 )
 
 func (v *Vault) ListMounts() (map[string]*models.MountOutput, error) {
+
 	apiMountList, err := v.vault.Sys().ListMounts()
 	if err != nil {
-		if strings.Contains(err.Error(), "route entry not found") {
-			return make(map[string]*models.MountOutput), nil
-		}
-		return nil, fmt.Errorf("failed to retrieve secret mounts: %w", err)
+		v.Logger.Warn().Err(err).Msg("Unable to access sys/mounts, attempting to use fallback method.\n")
+		return v.listMountsFallback()
 	}
 
 	// Convert api.MountOutput to MountOutput
@@ -22,9 +22,36 @@ func (v *Vault) ListMounts() (map[string]*models.MountOutput, error) {
 	for k, v := range apiMountList {
 		mountList[k] = toMount(v)
 	}
-
 	return mountList, nil
 
+}
+
+func (v *Vault) listMountsFallback() (map[string]*models.MountOutput, error) {
+	req := v.vault.NewRequest("GET", "/v1/sys/internal/ui/mounts")
+	resp, err := v.vault.RawRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve secret mounts: %w", err)
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var response models.UiMountsResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// Convert models.MountOutput to api.MountOutput
+	mountList := make(map[string]*models.MountOutput)
+	for k, v := range response.Data.Secret {
+		mountList[k] = v
+	}
+
+	return mountList, nil
 }
 
 func (v *Vault) AllMounts() (map[string]*models.MountOutput, error) {

--- a/internal/vault/mounts.go
+++ b/internal/vault/mounts.go
@@ -3,7 +3,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/dkyanakiev/vaulty/internal/models"
 	"github.com/hashicorp/vault/api"
@@ -27,14 +27,13 @@ func (v *Vault) ListMounts() (map[string]*models.MountOutput, error) {
 }
 
 func (v *Vault) listMountsFallback() (map[string]*models.MountOutput, error) {
-	req := v.vault.NewRequest("GET", "/v1/sys/internal/ui/mounts")
-	resp, err := v.vault.RawRequest(req)
+
+	resp, err := v.vault.Logical().ReadRaw("/sys/internal/ui/mounts")
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve secret mounts: %w", err)
 	}
 
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}


### PR DESCRIPTION
Not every user has access to `sys/mounts` so adding a fallback method.
This is the same method used by the UI to list mounts for users. 
Sadly it has no built in method in the api pkg.