### PR TITLE
feat: allow for vault tocken cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.9] - 2024-04-28
+
+## Added
+
+-- Vault cache token lookup
+
 ## [0.1.8] - 2024-04-28
 
 ## Fixed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,6 +67,13 @@ Example: [`~/myuser/.vaul7y.yaml`](./examples/vaul7y.yaml)
 Or alternatively pass a config file as an argument using `-c <path/file.yaml>`  
 Example: `vaul7y -c ./new-env.yml`
 
+#### Authentication and variables priority
+Variables will be loaded in the following order, with the next superseding the previous ones:
+
+1. Will check for vault [token cache](https://developer.hashicorp.com/vault/docs/commands#authenticating-to-vault)
+2. Read from env variables
+3. Config file 
+
 ### Features
 
 Currently the capabilities are limited. 


### PR DESCRIPTION
Solves https://github.com/dkyanakiev/vaul7y/issues/19

Will default to cached token > env variables > config file

Checks for the existance of a file `.vault-token` in the home directory.