### PR TITLE
Big performance update and cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,13 +1,16 @@
 ---
 name: Feature request
-about: Suggest an idea of a feature you would like
+about: Suggest an idea for a feature you would like
 title: ''
 labels: enhancement
 assignees: dkyanakiev
 
 ---
 
-**Is your feature request related to a problem? Please describe what it is.**
+**Which area does this relate to?**
+[e.g. Secret Engines / KV secrets, ACL Policies, Auth Methods, Namespaces, Header info, General navigation]
+
+**Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**

--- a/.github/ISSUE_TEMPLATE/issue_report.md
+++ b/.github/ISSUE_TEMPLATE/issue_report.md
@@ -12,7 +12,7 @@ A clear and concise description of what the bug is.
 
 **To reproduce**
 Steps to reproduce the behavior:
-1. Go to '...' page
+1. Go to '...' view
 2. Enter '...' key strokes
 3. See error
 
@@ -20,15 +20,31 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+If applicable, add screenshots or a screen recording to help explain your problem.
 
 **Please complete the following information:**
- - OS: [e.g. iOS, Windows]
- - Terminal [e.g. iterm2]
- - Version [e.g. v0.5.1 or how it was installed if "built from source"]
- - Vault cluster version. The full version string would indicate if its Ent or Oss version
- - Configuration options used, e.g. cli arguments, env vars, and/or `.vaul7y.yml` file
- - Vault permission policy (if applicable) 
+ - OS: [e.g. macOS 14, Ubuntu 22.04, Windows 11]
+ - Terminal: [e.g. iTerm2, Alacritty, Windows Terminal]
+ - Terminal dimensions: [run `echo "${COLUMNS}x${LINES}"` and paste the result]
+ - Vaul7y version: [e.g. v0.2.0 or "built from source @ commit abc1234"]
+ - Vault server version: [full version string, e.g. `Vault v1.15.4+ent` — indicates OSS vs Enterprise]
+ - KV engine version: [v1 or v2, if the issue is secret-related]
+ - Auth method in use: [e.g. token, AppRole, LDAP, OIDC]
+ - Namespaces involved: [yes / no — if yes, describe the namespace path]
+ - Configuration: [any relevant cli arguments, env vars, or `.vaul7y.yaml` options]
+ - Vault permission policy: [paste the relevant policy if the issue may be permission-related]
+
+**Log output**
+Enable debug logging before reproducing the issue:
+```shell
+export VAULTY_LOG_LEVEL=debug
+export VAULTY_LOG_FILE=/tmp/vaul7y-debug.log
+vaul7y
+```
+Then paste the relevant lines from `/tmp/vaul7y-debug.log` here:
+```
+<paste log lines>
+```
 
 **Additional context**
 Add any other context about the problem here.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
 project_name: vaul7y
-version: 1
+version: 2
 
 before:
   hooks:
@@ -49,7 +49,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc
@@ -65,7 +65,7 @@ brews:
   - name: vaul7y
     homepage: https://github.com/dkyanakiev/vaul7y
     description: "A simple terminal application/TUI for interacting with HashiCorp Vault."
-    folder: Formula
+    directory: Formula
     commit_author:
       name: "Dimitar Yanakiev"
       email: "dkyanakiev@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.2.0] - 2026-05-11
+
+### Added
+
+- **Auth Methods view** — `ctrl-a` from any view opens a table of all enabled auth methods showing mount path, type, and description
+- **Enriched header** — startup now fetches token TTL, attached policies, seal status, and cluster name; all are shown in the info bar alongside vault address and version
+- **Secret version management** (KV v2 only):
+  - `D` — soft-delete the current version (recoverable via rollback)
+  - `R` — rollback to a previous version by entering a version number
+  - `X` — permanently destroy a specific version (irreversible, requires confirmation)
+- **Secret metadata editing** (`M`) — edit `max_versions`, `cas_required`, and `delete_version_after` for KV v2 secrets directly in the TUI
+- **Policy editing** (`E` in policy ACL view) — edit policy rules in-place using the built-in text editor; save with `ctrl-w`, cancel with `esc`
+- **Format selector for secret create/update** — pressing `ctrl-n` (new secret), `P` (patch), or `U` (update) now prompts for JSON or Key-Value format before opening the editor:
+  - **JSON** — opens the existing JSON text editor (unchanged flow)
+  - **Key-Value** — opens a form with labelled Key/Value fields; an **Add Key** button appends additional pairs; pairs with blank keys are skipped on save; form pre-populates with existing data on `P`/`U`
+- **Policy ACL vim-style navigation** — when reading a policy file, `j`/`k` scroll one line, `d`/`u` scroll a half-page, `g`/`G` jump to top/bottom (arrow keys and Page Up/Down continue to work as before)
+
+### Fixed
+
+- **Blank secret view after rollback or metadata toggle** — `SecretObject()` now resets `ShowMetadata`, `ShowJson`, and `Editable` flags on every entry; previously these stale flags caused `Render()` to take the in-place refresh path on a cleared body slot, producing a blank view for all subsequent secrets
+- **Event loop blocking on vault operations** — delete version, destroy versions, rollback, and metadata update calls are now dispatched to background goroutines with `QueueUpdateDraw` for UI callbacks; previously they ran on the event goroutine and froze the UI during the network call
+- **DoneFunc state corruption after rollback/destroy prompts** — `promptRollback` and `promptDestroyVersion` now save and restore `TextInfoInput.Props.DoneFunc`; previously they permanently overrode it, breaking all subsequent text-input flows
+- **Non-blocking `Draw()`** — `Draw()` now uses `select/default` so it never blocks when the draw channel is already signalled
+- **Error propagation in vault KV client** — `Get()` and `GetMetadata()` now return the error to the caller instead of logging it and returning nil; callers can now surface fetch failures correctly
+
 ## [0.1.10] - 2025-06-15
 
 ## Fixed

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ dev: ## Build for the current development version
 	@echo "==> Building Vaul7y..."
 	@mkdir -p ./bin
 	@CGO_ENABLED=0 go build -o ./bin/vaul7y ./cmd/vaul7y
-	@rm -f $(GOPATH)/bin/vaul7y
-	@cp ./bin/vaul7y/vaul7y $(GOPATH)/bin/vaul7y
+	@mkdir -p $(shell go env GOPATH)/bin
+	@rm -f $(shell go env GOPATH)/bin/vaul7y
+	@cp ./bin/vaul7y $(shell go env GOPATH)/bin/vaul7y
 	@echo "==> Done"
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ The tool is in active development and is bug heavy. There are multiple things th
 If anyone decides to use this and wants to request a specific feature or even fix a bug - [please open an issue](https://github.com/dkyanakiev/vaul7y/issues/new/choose). :smile:
 
 ## Short term TODO list:
-1. [ ] Version select and rollback for secrets
+1. [x] Version select and rollback for secrets
 2. [ ] Work on PKI and Certs 

--- a/cmd/vaul7y/main.go
+++ b/cmd/vaul7y/main.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/config"
-	"github.com/dkyanakiev/vaulty/internal/state"
-	"github.com/dkyanakiev/vaulty/internal/vault"
-	"github.com/dkyanakiev/vaulty/internal/watcher"
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/view"
+	"github.com/dkyanakiev/vaul7y/internal/config"
+	"github.com/dkyanakiev/vaul7y/internal/state"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/watcher"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/view"
 	"github.com/gdamore/tcell/v2"
 	"github.com/jessevdk/go-flags"
 	"github.com/rivo/tview"
@@ -42,7 +42,13 @@ func main() {
 	cfg := config.LoadConfig(opts.ConfigFile)
 
 	logFile, logger := config.SetupLogger(cfg.VaultyLogLevel, cfg.VaultyLogFile)
-	defer logFile.Close()
+	defer func() {
+		if r := recover(); r != nil {
+			_ = logFile.Close()
+			panic(r)
+		}
+		_ = logFile.Close()
+	}()
 	tview.Styles.PrimitiveBackgroundColor = tcell.NewRGBColor(40, 44, 48)
 
 	vaultClient, err := vault.New(func(v *vault.Vault) error {
@@ -69,6 +75,8 @@ func main() {
 	info := component.NewInfo()
 	failure := component.NewInfo()
 	errorComp := component.NewError()
+	confirmComp := component.NewConfirm()
+	authTable := component.NewAuthTable()
 	components := &view.Components{
 		VaultInfo:      vaultInfo,
 		Commands:       commands,
@@ -79,9 +87,11 @@ func main() {
 		PolicyAclTable: policyAcl,
 		SecretsTable:   secrets,
 		SecretObjTable: secretObj,
+		AuthTable:      authTable,
 		Info:           info,
 		Error:          errorComp,
 		Failure:        failure,
+		Confirm:        confirmComp,
 		Logo:           logo,
 		Logger:         logger,
 		TogglesInfo:    toggles,
@@ -92,6 +102,7 @@ func main() {
 
 	//view.Init("0.0.1")
 	err = view.Layout.Container.Run()
+	view.Shutdown()
 	if err != nil {
 		log.Fatal("cannot initialize view.")
 	}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,14 +76,63 @@ Variables will be loaded in the following order, with the next superseding the p
 
 ### Features
 
-Currently the capabilities are limited. 
+#### Navigation
 
-* Support for navigation between KV mounts
-    * Currently only KV2
-* Looking up secret objects
-    * Show/hide secrets and coping data
-    * Update/patch secrets
-    * Create new secrets
-    * Filter paths/secrets 
-* Support for exploring and filtering ACL Policies
-* Namespace support for Enteprise versions
+| Key | Action |
+|-----|--------|
+| `ctrl-b` | Secret Engines (KV mounts) |
+| `ctrl-p` | ACL Policies |
+| `ctrl-t` | Namespaces (Enterprise) |
+| `ctrl-a` | Auth Methods |
+| `ctrl-c` | Quit |
+
+#### Secret Engines / KV Secrets
+
+* Browse KV v1 and v2 mounts
+* Filter paths and secrets with `/`
+* Jump directly to a path with `J`
+* Create new secrets with `ctrl-n` — choose JSON editor or Key-Value form
+
+#### Secret Object view
+
+| Key | Action |
+|-----|--------|
+| `h` | Toggle show/hide secret values |
+| `c` | Copy selected value to clipboard |
+| `j` (JSON view) | Toggle JSON view |
+| `t` | Toggle metadata panel (KV v2 only) |
+| `P` | Patch secret — choose JSON editor or Key-Value form |
+| `U` | Update (full replace) secret — choose JSON editor or Key-Value form |
+| `D` | Soft-delete current version (KV v2) |
+| `R` | Rollback to a previous version (KV v2) |
+| `X` | Permanently destroy a specific version (KV v2) |
+| `M` | Edit secret metadata — max_versions, cas_required, delete_version_after (KV v2) |
+| `b` / `esc` | Go back |
+
+When creating or updating via the Key-Value form, use **Add Key** to add multiple key-value pairs. Pairs with a blank key are ignored on save.
+
+#### ACL Policies
+
+* Browse and filter policies
+* `i` / `Enter` — inspect policy content
+* In policy view: `E` to edit, `ctrl-w` to save, `esc` to cancel
+* `c` — copy policy to clipboard
+* `w` — toggle word wrap
+* Vim-style reading navigation: `j`/`k` (line), `d`/`u` (half-page), `g`/`G` (top/bottom)
+
+#### Auth Methods
+
+* `ctrl-a` from any view — lists all enabled auth methods with their mount path, type, and description
+
+#### Header info bar
+
+At startup vaul7y fetches and displays:
+* Vault address and version
+* Seal status and cluster name
+* Token TTL and attached policies
+
+#### Namespace support (Enterprise)
+
+* `ctrl-t` — switch between namespaces
+* `ctrl-d` — return to default namespace
+* `ctrl-w` — return to root namespace

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dkyanakiev/vaulty
+module github.com/dkyanakiev/vaul7y
 
 go 1.21
 

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -31,47 +30,42 @@ func LoadConfig(cfgFile string) Config {
 	// Load the config from the YAML file
 	home, err := os.UserHomeDir()
 	if err != nil {
-		fmt.Println("Error getting user home directory")
+		fmt.Fprintln(os.Stderr, "Error getting user home directory")
 	}
 
 	var data []byte
 	if cfgFile == "" {
 		yamlFilePath := filepath.Join(home, ".vaul7y.yaml")
-		if _, err := os.Stat(yamlFilePath); os.IsNotExist(err) {
-			fmt.Printf("Config file does not exist: %s\n", yamlFilePath)
-		} else {
+		if _, err := os.Stat(yamlFilePath); !os.IsNotExist(err) {
 			data, err = os.ReadFile(yamlFilePath)
 			if err != nil {
-				fmt.Printf("Error reading YAML file: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Error reading YAML file: %v\n", err)
 			}
 		}
 	} else {
-		fmt.Println("Using config file: ", cfgFile)
 		data, err = os.ReadFile(cfgFile)
 		if err != nil {
-			fmt.Printf("Error reading YAML file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error reading YAML file: %v\n", err)
 		}
 	}
 
 	if data != nil {
 		err = yaml.Unmarshal(data, &config)
 		if err != nil {
-			fmt.Printf("Error parsing YAML file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error parsing YAML file: %v\n", err)
 		}
 	}
 
 	// Check for vault cache
 	home, err = os.UserHomeDir()
 	if err != nil {
-		fmt.Println("Error getting user home directory")
+		fmt.Fprintln(os.Stderr, "Error getting user home directory")
 	} else {
 		vaultTokenPath := filepath.Join(home, ".vault-token")
-		if _, err := os.Stat(vaultTokenPath); os.IsNotExist(err) {
-			fmt.Printf("Vault token file does not exist: %s\n", vaultTokenPath)
-		} else {
+		if _, err := os.Stat(vaultTokenPath); err == nil {
 			data, err := os.ReadFile(vaultTokenPath)
 			if err != nil {
-				fmt.Printf("Error reading vault token file: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Error reading vault token file: %v\n", err)
 			} else {
 				config.VaultToken = string(data)
 			}
@@ -106,7 +100,7 @@ func LoadConfig(cfgFile string) Config {
 	if vaultyRefreshRate := os.Getenv("VAULTY_REFRESH_RATE"); vaultyRefreshRate != "" {
 		vaultyRefreshRateInt, err := strconv.Atoi(vaultyRefreshRate)
 		if err != nil {
-			fmt.Printf("Error converting VAULTY_REFRESH_RATE to int: %v", err)
+			fmt.Fprintf(os.Stderr, "Error converting VAULTY_REFRESH_RATE to int: %v", err)
 		} else {
 			config.VaultyRefreshRate = vaultyRefreshRateInt
 		}
@@ -115,13 +109,13 @@ func LoadConfig(cfgFile string) Config {
 	if config.VaultToken == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			fmt.Println("Error getting user home directory")
+			fmt.Fprintln(os.Stderr, "Error getting user home directory")
 		} else {
 			vaultTokenPath := filepath.Join(home, ".vault-token")
 			if _, err := os.Stat(vaultTokenPath); err == nil {
 				data, err := os.ReadFile(vaultTokenPath)
 				if err != nil {
-					fmt.Printf("Error reading vault token file: %v\n", err)
+					fmt.Fprintf(os.Stderr, "Error reading vault token file: %v\n", err)
 				} else {
 					config.VaultToken = string(data)
 				}
@@ -130,12 +124,12 @@ func LoadConfig(cfgFile string) Config {
 	}
 
 	if config.VaultAddr == "" {
-		fmt.Println("VAULT_ADDR is not set. Please set it and try again.")
+		fmt.Fprintln(os.Stderr, "VAULT_ADDR is not set. Please set it and try again.")
 		os.Exit(1)
 	}
 
 	if config.VaultToken == "" {
-		fmt.Println("VAULT_TOKEN is not set. Please set it and try again.")
+		fmt.Fprintln(os.Stderr, "VAULT_TOKEN is not set. Please set it and try again.")
 		os.Exit(1)
 	}
 
@@ -149,13 +143,13 @@ func LoadConfig(cfgFile string) Config {
 			signal.Notify(ch, syscall.SIGTERM)
 
 			<-ch
-			fmt.Println("Dumping goroutines")
+			fmt.Fprintln(os.Stderr, "Dumping goroutines")
 			bufsize := int(10 * 1024 * 1024) // 10 MiB
 			buf := make([]byte, bufsize)
 			n := runtime.Stack(buf, true)
 			filename := fmt.Sprintf("%s.dump", config.VaultyLogFile)
 
-			ioutil.WriteFile(filename, buf[:n], 0644)
+			os.WriteFile(filename, buf[:n], 0644)
 			os.Exit(1)
 		}()
 

--- a/internal/config/configs_test.go
+++ b/internal/config/configs_test.go
@@ -1,0 +1,150 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dkyanakiev/vaul7y/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeConfig writes yaml to a temp file and returns its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "vaul7y.yaml")
+	require.NoError(t, os.WriteFile(f, []byte(content), 0600))
+	return f
+}
+
+// baseConfig is a minimal YAML that satisfies required fields so tests that
+// use t.Setenv for other assertions don't accidentally hit os.Exit(1).
+const baseYAML = `
+vault_addr: https://base.vault.example.com
+vault_token: base-token
+`
+
+func TestLoadConfig_YAML(t *testing.T) {
+	t.Run("non-auth fields parsed from yaml", func(t *testing.T) {
+		// Use env var for VAULT_TOKEN so the ~/.vault-token file on disk
+		// (if present) cannot override what we assert on for other fields.
+		t.Setenv("VAULT_TOKEN", "env-token")
+
+		cfg := config.LoadConfig(writeConfig(t, `
+vault_addr: https://yaml.vault.example.com
+vault_token: yaml-token
+vault_namespace: yaml-ns
+vaulty_log_file: /tmp/vaul7y.log
+vaulty_log_level: info
+vaulty_refresh_rate: 45
+`))
+		assert.Equal(t, "https://yaml.vault.example.com", cfg.VaultAddr)
+		assert.Equal(t, "yaml-ns", cfg.VaultNamespace)
+		assert.Equal(t, "/tmp/vaul7y.log", cfg.VaultyLogFile)
+		assert.Equal(t, "info", cfg.VaultyLogLevel)
+		assert.Equal(t, 45, cfg.VaultyRefreshRate)
+		// Token was overridden by env, so we only check it came from env.
+		assert.Equal(t, "env-token", cfg.VaultToken)
+	})
+
+	t.Run("default refresh rate applied when yaml omits it", func(t *testing.T) {
+		t.Setenv("VAULT_TOKEN", "env-token")
+		cfg := config.LoadConfig(writeConfig(t, `
+vault_addr: https://yaml.vault.example.com
+vault_token: yaml-token
+`))
+		assert.Equal(t, 30, cfg.VaultyRefreshRate)
+	})
+}
+
+func TestLoadConfig_EnvVars(t *testing.T) {
+	base := writeConfig(t, baseYAML)
+
+	t.Run("VAULT_ADDR env var overrides yaml", func(t *testing.T) {
+		t.Setenv("VAULT_ADDR", "https://env.vault.example.com")
+		t.Setenv("VAULT_TOKEN", "env-token")
+
+		cfg := config.LoadConfig(base)
+
+		assert.Equal(t, "https://env.vault.example.com", cfg.VaultAddr)
+	})
+
+	t.Run("VAULT_NAMESPACE env var loaded", func(t *testing.T) {
+		t.Setenv("VAULT_TOKEN", "env-token")
+		t.Setenv("VAULT_NAMESPACE", "env-ns")
+
+		cfg := config.LoadConfig(base)
+
+		assert.Equal(t, "env-ns", cfg.VaultNamespace)
+	})
+
+	t.Run("VAULTY_REFRESH_RATE from env", func(t *testing.T) {
+		t.Setenv("VAULT_TOKEN", "env-token")
+		t.Setenv("VAULTY_REFRESH_RATE", "60")
+
+		cfg := config.LoadConfig(base)
+
+		assert.Equal(t, 60, cfg.VaultyRefreshRate)
+	})
+
+	t.Run("invalid VAULTY_REFRESH_RATE falls back to default 30", func(t *testing.T) {
+		t.Setenv("VAULT_TOKEN", "env-token")
+		t.Setenv("VAULTY_REFRESH_RATE", "notanumber")
+
+		cfg := config.LoadConfig(base)
+
+		assert.Equal(t, 30, cfg.VaultyRefreshRate)
+	})
+
+	t.Run("VAULTY_LOG_FILE and VAULTY_LOG_LEVEL from env", func(t *testing.T) {
+		t.Setenv("VAULT_TOKEN", "env-token")
+		t.Setenv("VAULTY_LOG_FILE", "/tmp/test.log")
+		t.Setenv("VAULTY_LOG_LEVEL", "debug")
+
+		cfg := config.LoadConfig(base)
+
+		assert.Equal(t, "/tmp/test.log", cfg.VaultyLogFile)
+		assert.Equal(t, "debug", cfg.VaultyLogLevel)
+	})
+
+	t.Run("TLS env vars are loaded", func(t *testing.T) {
+		t.Setenv("VAULT_TOKEN", "env-token")
+		t.Setenv("VAULT_CACERT", "/etc/ssl/ca.pem")
+		t.Setenv("VAULT_CLIENT_CERT", "/etc/ssl/client.pem")
+		t.Setenv("VAULT_CLIENT_KEY", "/etc/ssl/client.key")
+
+		cfg := config.LoadConfig(base)
+
+		assert.Equal(t, "/etc/ssl/ca.pem", cfg.VaultCaCert)
+		assert.Equal(t, "/etc/ssl/client.pem", cfg.VaultClientCert)
+		assert.Equal(t, "/etc/ssl/client.key", cfg.VaultClientKey)
+	})
+}
+
+func TestLoadConfig_Priority(t *testing.T) {
+	t.Run("env var wins over yaml for VAULT_ADDR", func(t *testing.T) {
+		cfgFile := writeConfig(t, `
+vault_addr: https://yaml.vault.example.com
+vault_token: yaml-token
+`)
+		t.Setenv("VAULT_ADDR", "https://from-env.vault.example.com")
+		t.Setenv("VAULT_TOKEN", "env-token")
+
+		cfg := config.LoadConfig(cfgFile)
+
+		assert.Equal(t, "https://from-env.vault.example.com", cfg.VaultAddr)
+	})
+
+	t.Run("env var wins over yaml for VAULT_TOKEN", func(t *testing.T) {
+		cfgFile := writeConfig(t, `
+vault_addr: https://yaml.vault.example.com
+vault_token: from-yaml
+`)
+		t.Setenv("VAULT_TOKEN", "from-env")
+
+		cfg := config.LoadConfig(cfgFile)
+
+		assert.Equal(t, "from-env", cfg.VaultToken)
+	})
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -121,7 +121,7 @@ type SecretAuth struct {
 
 type SecretWrapInfo struct {
 	Token           string    `json:"token"`
-	Accessor        string    `json:"accessor`
+	Accessor        string    `json:"accessor"`
 	TTL             int       `json:"ttl"`
 	CreationTime    time.Time `json:"creation_time"`
 	CreationPath    string    `json:"creation_path"`
@@ -230,4 +230,11 @@ type Version struct {
 	CreatedTime  string `json:"created_time"`
 	DeletionTime string `json:"deletion_time"`
 	Destroyed    bool   `json:"destroyed"`
+}
+
+type AuthMethod struct {
+	Type        string
+	Description string
+	Accessor    string
+	Local       bool
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,12 +1,15 @@
 package state
 
 import (
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"sync"
+
+	"github.com/dkyanakiev/vaul7y/internal/models"
 	"github.com/hashicorp/vault/api"
 	"github.com/rivo/tview"
 )
 
 type State struct {
+	mu sync.RWMutex
 	VaultAddress string
 	VaultVersion string
 	Mounts       map[string]*models.MountOutput
@@ -29,6 +32,12 @@ type State struct {
 	NewSecretName      string
 	Enterprise         bool
 
+	AuthMethods   map[string]*models.AuthMethod
+	TokenTTL      int64
+	TokenPolicies []string
+	SealStatus    string
+	ClusterName   string
+
 	Elements *Elements
 	Toggle   *Toggle
 	Filter   *Filter
@@ -38,6 +47,7 @@ type State struct {
 type Toggle struct {
 	Search       bool
 	JumpToPolicy bool
+	JumpToPath   bool
 	TextInput    bool
 }
 
@@ -60,3 +70,8 @@ func New() *State {
 		Filter:   &Filter{},
 	}
 }
+
+func (s *State) Lock()    { s.mu.Lock() }
+func (s *State) Unlock()  { s.mu.Unlock() }
+func (s *State) RLock()   { s.mu.RLock() }
+func (s *State) RUnlock() { s.mu.RUnlock() }

--- a/internal/vault/auth.go
+++ b/internal/vault/auth.go
@@ -1,0 +1,25 @@
+package vault
+
+import (
+	"fmt"
+
+	"github.com/dkyanakiev/vaul7y/internal/models"
+)
+
+func (v *Vault) ListAuthMethods() (map[string]*models.AuthMethod, error) {
+	auths, err := v.vault.Sys().ListAuth()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list auth methods: %w", err)
+	}
+
+	result := make(map[string]*models.AuthMethod, len(auths))
+	for path, mount := range auths {
+		result[path] = &models.AuthMethod{
+			Type:        mount.Type,
+			Description: mount.Description,
+			Accessor:    mount.Accessor,
+			Local:       mount.Local,
+		}
+	}
+	return result, nil
+}

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -2,9 +2,11 @@ package vault
 
 import (
 	"context"
+	"strings"
+	"sync"
 
-	"github.com/dkyanakiev/vaulty/internal/config"
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/config"
+	"github.com/dkyanakiev/vaul7y/internal/models"
 	"github.com/hashicorp/vault/api"
 	"github.com/rs/zerolog"
 )
@@ -24,6 +26,39 @@ type Vault struct {
 	Secret   Secret
 	Logger   *zerolog.Logger
 	Version  string
+
+	mountsMu    sync.RWMutex
+	mountsCache map[string]*models.MountOutput
+}
+
+// kvVersionForMount returns "1" or "2" for a KV mount by consulting the cached
+// mount list. It defaults to "2" if the mount is not found or not a KV mount.
+func (v *Vault) kvVersionForMount(mount string) string {
+	v.mountsMu.RLock()
+	defer v.mountsMu.RUnlock()
+
+	key := mount
+	if !strings.HasSuffix(key, "/") {
+		key += "/"
+	}
+
+	m, ok := v.mountsCache[key]
+	if !ok {
+		m, ok = v.mountsCache[mount]
+		if !ok {
+			return "2"
+		}
+	}
+
+	if m.Type != models.MountTypeKV {
+		return "2"
+	}
+
+	// KV v2 always sets Options["version"] = "2"; anything else is v1.
+	if m.Options != nil && m.Options["version"] == "2" {
+		return "2"
+	}
+	return "1"
 }
 
 //go:generate counterfeiter . Logical

--- a/internal/vault/kv.go
+++ b/internal/vault/kv.go
@@ -9,7 +9,8 @@ import (
 func (v *Vault) Get(ctx context.Context, path string) (*api.KVSecret, error) {
 	secret, err := v.KV2.Get(ctx, path)
 	if err != nil {
-		v.Logger.Err(err).Msgf("filed to retrieve secret: %s", err)
+		v.Logger.Err(err).Msgf("failed to retrieve secret: %s", err)
+		return nil, err
 	}
 	return secret, nil
 }
@@ -17,7 +18,8 @@ func (v *Vault) Get(ctx context.Context, path string) (*api.KVSecret, error) {
 func (v *Vault) GetMetadata(ctx context.Context, path string) (*api.KVMetadata, error) {
 	secret, err := v.KV2.GetMetadata(ctx, path)
 	if err != nil {
-		v.Logger.Err(err).Msgf("filed to retrieve secret: %s", err)
+		v.Logger.Err(err).Msgf("failed to retrieve secret metadata: %s", err)
+		return nil, err
 	}
 	return secret, nil
 }

--- a/internal/vault/kv_test.go
+++ b/internal/vault/kv_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/internal/vault"
-	"github.com/dkyanakiev/vaulty/internal/vault/vaultfakes"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/vault/vaultfakes"
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/vault/kv_test.go
+++ b/internal/vault/kv_test.go
@@ -2,13 +2,21 @@ package vault_test
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/dkyanakiev/vaul7y/internal/vault"
 	"github.com/dkyanakiev/vaul7y/internal/vault/vaultfakes"
 	"github.com/hashicorp/vault/api"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
+
+func discardLogger() *zerolog.Logger {
+	l := zerolog.New(io.Discard)
+	return &l
+}
 
 func TestGet(t *testing.T) {
 	ctx := context.Background()
@@ -30,6 +38,25 @@ func TestGet(t *testing.T) {
 
 }
 
+func TestGet_Error(t *testing.T) {
+	ctx := context.Background()
+	path := "testpath"
+
+	fakeKV2 := &vaultfakes.FakeKV2{}
+	vaultErr := errors.New("permission denied")
+	fakeKV2.GetReturns(nil, vaultErr)
+
+	v := &vault.Vault{
+		KV2:    fakeKV2,
+		Logger: discardLogger(),
+	}
+
+	secret, err := v.Get(ctx, path)
+
+	assert.ErrorIs(t, err, vaultErr)
+	assert.Nil(t, secret)
+}
+
 func TestGetMetadata(t *testing.T) {
 	ctx := context.Background()
 	path := "testpath"
@@ -47,4 +74,23 @@ func TestGetMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, secret)
 	fakeKV2.GetMetadata(ctx, path)
+}
+
+func TestGetMetadata_Error(t *testing.T) {
+	ctx := context.Background()
+	path := "testpath"
+
+	fakeKV2 := &vaultfakes.FakeKV2{}
+	vaultErr := errors.New("secret not found")
+	fakeKV2.GetMetadataReturns(nil, vaultErr)
+
+	v := &vault.Vault{
+		KV2:    fakeKV2,
+		Logger: discardLogger(),
+	}
+
+	meta, err := v.GetMetadata(ctx, path)
+
+	assert.ErrorIs(t, err, vaultErr)
+	assert.Nil(t, meta)
 }

--- a/internal/vault/logical_test.go
+++ b/internal/vault/logical_test.go
@@ -3,8 +3,8 @@ package vault_test
 import (
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/internal/vault"
-	"github.com/dkyanakiev/vaulty/internal/vault/vaultfakes"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/vault/vaultfakes"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/vault/mounts.go
+++ b/internal/vault/mounts.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/models"
 	"github.com/hashicorp/vault/api"
 )
 
@@ -59,6 +59,11 @@ func (v *Vault) AllMounts() (map[string]*models.MountOutput, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve mounts: %w", err)
 	}
+
+	v.mountsMu.Lock()
+	v.mountsCache = mounts
+	v.mountsMu.Unlock()
+
 	return mounts, nil
 }
 

--- a/internal/vault/mounts_test.go
+++ b/internal/vault/mounts_test.go
@@ -3,8 +3,8 @@ package vault_test
 import (
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/internal/vault"
-	"github.com/dkyanakiev/vaulty/internal/vault/vaultfakes"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/vault/vaultfakes"
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/vault/policy.go
+++ b/internal/vault/policy.go
@@ -22,3 +22,7 @@ func (v *Vault) GetPolicyInfo(name string) (string, error) {
 	}
 	return policy, nil
 }
+
+func (v *Vault) UpdatePolicy(name, rules string) error {
+	return v.vault.Sys().PutPolicy(name, rules)
+}

--- a/internal/vault/policy_test.go
+++ b/internal/vault/policy_test.go
@@ -3,8 +3,8 @@ package vault_test
 import (
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/internal/vault"
-	"github.com/dkyanakiev/vaulty/internal/vault/vaultfakes"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/vault/vaultfakes"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/vault/secret.go
+++ b/internal/vault/secret.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/models"
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"
 )
@@ -36,8 +36,14 @@ func (v *Vault) ListSecrets(path string) (*api.Secret, error) {
 
 func (v *Vault) ListNestedSecrets(mount, path string) ([]models.SecretPath, error) {
 	var secretPaths []models.SecretPath
-	mountPath := fmt.Sprintf("%s/metadata/%s", mount, path)
-	mountPath = sanitizePath(mountPath)
+
+	var mountPath string
+	if v.kvVersionForMount(mount) == "1" {
+		mountPath = sanitizePath(fmt.Sprintf("%s/%s", mount, path))
+	} else {
+		mountPath = sanitizePath(fmt.Sprintf("%s/metadata/%s", mount, path))
+	}
+
 	secrets, err := v.vault.Logical().List(mountPath)
 
 	v.Logger.Debug().Msg(fmt.Sprintf("Listing secrets for path: %s", mountPath))
@@ -76,8 +82,15 @@ func (v *Vault) ListNestedSecrets(mount, path string) ([]models.SecretPath, erro
 }
 
 func (v *Vault) GetSecretData(mount, path string) (*api.Secret, error) {
-	secretPath := fmt.Sprintf("%s/data/%s", mount, path)
-	secretPath = sanitizePath(secretPath)
+	kvVer := v.kvVersionForMount(mount)
+
+	var secretPath string
+	if kvVer == "1" {
+		secretPath = sanitizePath(fmt.Sprintf("%s/%s", mount, path))
+	} else {
+		secretPath = sanitizePath(fmt.Sprintf("%s/data/%s", mount, path))
+	}
+
 	secretData, err := v.vault.Logical().Read(secretPath)
 	if err != nil {
 		v.Logger.Err(err).Msgf("failed to read secret: %s", err)
@@ -89,10 +102,25 @@ func (v *Vault) GetSecretData(mount, path string) (*api.Secret, error) {
 		return nil, fmt.Errorf("no data found at %s", secretPath)
 	}
 
+	// Normalize v1 response to match the v2 structure the UI expects:
+	// v1 returns {"key":"value"} at .Data; v2 returns {"data":{"key":"value"},...} at .Data.
+	if kvVer == "1" {
+		return &api.Secret{
+			Data: map[string]interface{}{
+				"data": secretData.Data,
+			},
+		}, nil
+	}
+
 	return secretData, nil
 }
 
 func (v *Vault) GetSecretMetadata(mount, path string) (*models.Metadata, error) {
+	// KV v1 has no metadata endpoint.
+	if v.kvVersionForMount(mount) == "1" {
+		return nil, nil
+	}
+
 	secretPath := fmt.Sprintf("%s/metadata/%s", mount, path)
 	secretPath = sanitizePath(secretPath)
 	var metadata models.Metadata
@@ -123,6 +151,21 @@ func (v *Vault) GetSecretMetadata(mount, path string) (*models.Metadata, error) 
 
 func (v *Vault) UpdateSecretObjectKV2(mount string, path string, patch bool, data map[string]interface{}) error {
 	ctx := context.Background()
+
+	// KV v1: write flat data directly — no versioning, no patch support.
+	if v.kvVersionForMount(mount) == "1" {
+		secretPath := sanitizePath(fmt.Sprintf("%s/%s", mount, path))
+		flatData := data
+		if d, ok := data["data"].(map[string]interface{}); ok {
+			flatData = d
+		}
+		_, err := v.vault.Logical().WriteWithContext(ctx, secretPath, flatData)
+		if err != nil {
+			return fmt.Errorf("failed to update v1 secret: %w", err)
+		}
+		v.Logger.Info().Msg("v1 secret updated successfully")
+		return nil
+	}
 
 	data = prepareDataForWrite(data)
 	v.Logger.Debug().Msg(fmt.Sprintf("Patch FLAG: %v", patch))
@@ -414,21 +457,78 @@ func (v *Vault) PatchWithoutWrap(ctx context.Context, mountPath string, secretPa
 	return kvs, nil
 }
 
-func (v *Vault) CreateNewSecret(mount string, path string) error {
-	secretPath := fmt.Sprintf("%s/data/%s", mount, path)
-	secretPath = sanitizePath(secretPath)
+func (v *Vault) DeleteCurrentSecretVersion(mount, path string) error {
+	if v.kvVersionForMount(mount) == "1" {
+		secretPath := sanitizePath(fmt.Sprintf("%s/%s", mount, path))
+		_, err := v.vault.Logical().Delete(secretPath)
+		return err
+	}
+	secretPath := sanitizePath(fmt.Sprintf("%s/data/%s", mount, path))
+	_, err := v.vault.Logical().Delete(secretPath)
+	return err
+}
 
-	data := map[string]interface{}{
-		"data": make(map[string]interface{}),
+func (v *Vault) DestroySecretVersions(mount, path string, versions []int) error {
+	destroyPath := sanitizePath(fmt.Sprintf("%s/destroy/%s", mount, path))
+	versionIfaces := make([]interface{}, len(versions))
+	for i, v := range versions {
+		versionIfaces[i] = v
+	}
+	_, err := v.vault.Logical().Write(destroyPath, map[string]interface{}{
+		"versions": versionIfaces,
+	})
+	return err
+}
+
+func (v *Vault) RollbackSecret(mount, path string, version int) error {
+	ctx := context.Background()
+	readPath := sanitizePath(fmt.Sprintf("%s/data/%s", mount, path))
+
+	secret, err := v.vault.Logical().ReadWithData(readPath, map[string][]string{
+		"version": {strconv.Itoa(version)},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to read version %d: %w", version, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return fmt.Errorf("version %d not found", version)
 	}
 
-	secret, err := v.vault.Logical().Write(secretPath, data)
+	dataMap, ok := secret.Data["data"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected data format for version %d", version)
+	}
+
+	_, err = v.vault.Logical().WriteWithContext(ctx, readPath, map[string]interface{}{
+		"data": dataMap,
+	})
+	return err
+}
+
+func (v *Vault) UpdateSecretMetadata(mount, path string, opts map[string]interface{}) error {
+	metaPath := sanitizePath(fmt.Sprintf("%s/metadata/%s", mount, path))
+	_, err := v.vault.Logical().Write(metaPath, opts)
+	return err
+}
+
+func (v *Vault) CreateNewSecret(mount string, path string) error {
+	var secretPath string
+	var data map[string]interface{}
+
+	if v.kvVersionForMount(mount) == "1" {
+		secretPath = sanitizePath(fmt.Sprintf("%s/%s", mount, path))
+		// KV v1 rejects an empty body; seed with a placeholder the user can overwrite.
+		data = map[string]interface{}{"placeholder": ""}
+	} else {
+		secretPath = sanitizePath(fmt.Sprintf("%s/data/%s", mount, path))
+		data = map[string]interface{}{
+			"data": make(map[string]interface{}),
+		}
+	}
+
+	_, err := v.vault.Logical().Write(secretPath, data)
 	if err != nil {
 		return fmt.Errorf("failed to create secret: %w", err)
-	}
-
-	if secret == nil {
-		return fmt.Errorf("no secret was written to %s", secretPath)
 	}
 
 	return nil

--- a/internal/vault/token.go
+++ b/internal/vault/token.go
@@ -1,0 +1,59 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func (v *Vault) TokenInfo() (ttl int64, policies []string, err error) {
+	secret, err := v.vault.Auth().Token().LookupSelf()
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to lookup token: %w", err)
+	}
+	if secret == nil || secret.Data == nil {
+		return 0, nil, fmt.Errorf("empty token lookup response")
+	}
+
+	if raw, ok := secret.Data["ttl"]; ok {
+		switch n := raw.(type) {
+		case float64:
+			ttl = int64(n)
+		case int64:
+			ttl = n
+		case json.Number:
+			ttl, _ = n.Int64()
+		}
+	}
+
+	if raw, ok := secret.Data["policies"]; ok {
+		if list, ok := raw.([]interface{}); ok {
+			for _, p := range list {
+				if s, ok := p.(string); ok {
+					policies = append(policies, s)
+				}
+			}
+		}
+	}
+
+	return ttl, policies, nil
+}
+
+func (v *Vault) SealStatus() (status string, clusterName string, err error) {
+	health, err := v.Sys.Health()
+	if err != nil {
+		return "Unknown", "", fmt.Errorf("failed to get health: %w", err)
+	}
+
+	switch {
+	case health.Sealed:
+		status = "Sealed"
+	case strings.Contains(strings.ToLower(health.ReplicationPerformanceMode), "standby"),
+		strings.Contains(strings.ToLower(health.ReplicationDRMode), "standby"):
+		status = "Standby"
+	default:
+		status = "Active"
+	}
+
+	return status, health.ClusterName, nil
+}

--- a/internal/vault/vaultfakes/fake_client.go
+++ b/internal/vault/vaultfakes/fake_client.go
@@ -4,7 +4,7 @@ package vaultfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
 )
 
 type FakeClient struct {

--- a/internal/vault/vaultfakes/fake_kv2.go
+++ b/internal/vault/vaultfakes/fake_kv2.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
 	"github.com/hashicorp/vault/api"
 )
 

--- a/internal/vault/vaultfakes/fake_logical.go
+++ b/internal/vault/vaultfakes/fake_logical.go
@@ -4,7 +4,7 @@ package vaultfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
 	"github.com/hashicorp/vault/api"
 )
 

--- a/internal/vault/vaultfakes/fake_sys.go
+++ b/internal/vault/vaultfakes/fake_sys.go
@@ -4,7 +4,7 @@ package vaultfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
 	"github.com/hashicorp/vault/api"
 )
 

--- a/internal/watcher/activity.go
+++ b/internal/watcher/activity.go
@@ -9,16 +9,10 @@ func (a *ActivityPool) Add(act chan struct{}) {
 }
 
 func (a *ActivityPool) DeactivateAll() {
-	for a.hasActivities() {
-		a.deactivate()
-	}
-}
-
-func (a *ActivityPool) deactivate() {
-	if a.hasActivities() {
-		ch := a.Activities[0]
-		ch <- struct{}{}
-		a.Activities = a.Activities[1:]
+	activities := a.Activities
+	a.Activities = nil
+	for _, ch := range activities {
+		go func(c chan struct{}) { c <- struct{}{} }(ch)
 	}
 }
 

--- a/internal/watcher/activity_test.go
+++ b/internal/watcher/activity_test.go
@@ -3,7 +3,7 @@ package watcher_test
 import (
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/internal/watcher"
+	"github.com/dkyanakiev/vaul7y/internal/watcher"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/watcher/auth.go
+++ b/internal/watcher/auth.go
@@ -1,0 +1,41 @@
+package watcher
+
+import (
+	"time"
+
+	"github.com/dkyanakiev/vaul7y/internal/models"
+)
+
+func (w *Watcher) SubscribeToAuthMethods(notify func()) {
+	w.updateAuthMethods()
+	w.Subscribe(notify, "auth")
+
+	stop := make(chan struct{})
+	w.activities.Add(stop)
+	ticker := time.NewTicker(w.interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				w.updateAuthMethods()
+				w.Notify("auth")
+			case <-stop:
+				return
+			}
+		}
+	}()
+}
+
+func (w *Watcher) updateAuthMethods() {
+	w.logger.Debug().Msg("Updating auth methods")
+	auths, err := w.vault.ListAuthMethods()
+	if err != nil {
+		w.logger.Err(err).Msg("failed to list auth methods")
+		w.NotifyHandler(models.HandleError, err.Error())
+		return
+	}
+	w.state.Lock()
+	w.state.AuthMethods = auths
+	w.state.Unlock()
+}

--- a/internal/watcher/mounts.go
+++ b/internal/watcher/mounts.go
@@ -4,18 +4,18 @@ import (
 	"log"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/models"
 )
 
 func (w *Watcher) SubscribeToMounts(notify func()) {
 	w.UpdateMounts()
 	w.Subscribe(notify, "mounts")
-	w.Notify("mounts")
 
 	stop := make(chan struct{})
 	w.activities.Add(stop)
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(w.interval)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
@@ -38,5 +38,7 @@ func (w *Watcher) UpdateMounts() {
 		log.Println(err)
 		w.NotifyHandler(models.HandleError, err.Error())
 	}
+	w.state.Lock()
 	w.state.Mounts = mounts
+	w.state.Unlock()
 }

--- a/internal/watcher/mounts_test.go
+++ b/internal/watcher/mounts_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/state"
-	"github.com/dkyanakiev/vaulty/internal/watcher"
-	"github.com/dkyanakiev/vaulty/internal/watcher/watcherfakes"
+	"github.com/dkyanakiev/vaul7y/internal/state"
+	"github.com/dkyanakiev/vaul7y/internal/watcher"
+	"github.com/dkyanakiev/vaul7y/internal/watcher/watcherfakes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,5 +23,7 @@ func TestSubscribeToMounts(t *testing.T) {
 
 	fakeWatcher.SubscribeToMounts(notify)
 
-	assert.True(t, notifyCalled)
+	// notify is no longer called synchronously on subscribe; the view's direct
+	// update() call handles the initial render, avoiding a QueueUpdateDraw deadlock.
+	assert.False(t, notifyCalled)
 }

--- a/internal/watcher/namespaces.go
+++ b/internal/watcher/namespaces.go
@@ -4,18 +4,18 @@ import (
 	"log"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/models"
 )
 
 func (w *Watcher) SubscribeToNamespaces(notify func()) {
 	w.UpdateNamespaces()
 	w.Subscribe(notify, "namespaces")
-	w.Notify("namespaces")
 
 	stop := make(chan struct{})
 	w.activities.Add(stop)
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(w.interval)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
@@ -40,5 +40,7 @@ func (w *Watcher) UpdateNamespaces() {
 		w.NotifyHandler(models.HandleError, err.Error())
 	}
 	w.logger.Debug().Msgf("Namespaces: %v", namespaces)
+	w.state.Lock()
 	w.state.Namespaces = namespaces
+	w.state.Unlock()
 }

--- a/internal/watcher/policies.go
+++ b/internal/watcher/policies.go
@@ -4,19 +4,19 @@ import (
 	"log"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/models"
 )
 
 func (w *Watcher) SubscribeToPolicies(notify func()) {
 
 	w.updatePolicies()
 	w.Subscribe(notify, "policies")
-	w.Notify("policies")
 
 	stop := make(chan struct{})
 	w.activities.Add(stop)
 	ticker := time.NewTicker(w.interval)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
@@ -39,5 +39,7 @@ func (w *Watcher) updatePolicies() {
 		w.NotifyHandler(models.HandleError, err.Error())
 		log.Println(err)
 	}
+	w.state.Lock()
 	w.state.PolicyList = policies
+	w.state.Unlock()
 }

--- a/internal/watcher/policyacl.go
+++ b/internal/watcher/policyacl.go
@@ -4,18 +4,18 @@ import (
 	"log"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/models"
 )
 
 func (w *Watcher) SubscribeToPoliciesACL(notify func()) {
 
 	w.readPolicy()
 	w.Subscribe(notify, "policyacl")
-	w.Notify("policyacl")
 	stop := make(chan struct{})
 	w.activities.Add(stop)
 	ticker := time.NewTicker(w.interval)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
@@ -48,5 +48,7 @@ func (w *Watcher) readPolicy() {
 		log.Println(err)
 	}
 
+	w.state.Lock()
 	w.state.PolicyACL = policy
+	w.state.Unlock()
 }

--- a/internal/watcher/secretobj.go
+++ b/internal/watcher/secretobj.go
@@ -3,18 +3,18 @@ package watcher
 import (
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/models"
 )
 
 func (w *Watcher) SubscribeToSecret(selectedMount, selectedPath string, notify func()) {
 	w.updateSecretState(selectedMount, selectedPath)
 	w.Subscribe(notify, "secret")
-	w.Notify("secret")
 
 	stop := make(chan struct{})
 	w.activities.Add(stop)
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(w.interval)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
@@ -43,8 +43,10 @@ func (w *Watcher) updateSecretState(selectedMount, selectedPath string) {
 	if err != nil && err2 != nil {
 		w.NotifyHandler(models.HandleError, "Unable to return secret data or metadata")
 	}
+	w.state.Lock()
 	w.state.SelectedSecret = secret
 	w.state.SelectedSecretMeta = metadata
+	w.state.Unlock()
 
 }
 

--- a/internal/watcher/secrets.go
+++ b/internal/watcher/secrets.go
@@ -3,18 +3,18 @@ package watcher
 import (
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/models"
 )
 
 func (w *Watcher) SubscribeToSecrets(selectedMount, selectedPath string, notify func()) {
 	w.updateSecrets(selectedMount, selectedPath)
 	w.Subscribe(notify, "secrets")
-	w.Notify("secrets")
 
 	stop := make(chan struct{})
 	w.activities.Add(stop)
 	ticker := time.NewTicker(w.interval)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
@@ -38,6 +38,8 @@ func (w *Watcher) updateSecrets(selectedMount, selectedPath string) {
 		w.NotifyHandler(models.HandleError, err.Error())
 
 	}
+	w.state.Lock()
 	w.state.SecretsData = secrets
+	w.state.Unlock()
 
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -3,8 +3,8 @@ package watcher
 import (
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/internal/state"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/state"
 	"github.com/hashicorp/vault/api"
 	"github.com/rs/zerolog"
 )
@@ -27,8 +27,9 @@ type Vault interface {
 	ListNamespaces() ([]string, error)
 	GetSecretData(string, string) (*api.Secret, error)
 	GetSecretMetadata(string, string) (*models.Metadata, error)
-	//GetPolicy(string) (string, error)
-	//ListPolicies() ([]string, error)
+	ListAuthMethods() (map[string]*models.AuthMethod, error)
+	TokenInfo() (ttl int64, policies []string, err error)
+	SealStatus() (status string, clusterName string, err error)
 }
 
 // Wather is used to track changes to the Vault instance and update the state.
@@ -50,6 +51,10 @@ type subscriber struct {
 }
 
 func NewWatcher(state *state.State, vault Vault, interval time.Duration, logger *zerolog.Logger) *Watcher {
+	if logger == nil {
+		nop := zerolog.Nop()
+		logger = &nop
+	}
 	return &Watcher{
 		state:      state,
 		vault:      vault,

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/internal/state"
-	"github.com/dkyanakiev/vaulty/internal/watcher"
-	"github.com/dkyanakiev/vaulty/internal/watcher/watcherfakes"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/state"
+	"github.com/dkyanakiev/vaul7y/internal/watcher"
+	"github.com/dkyanakiev/vaul7y/internal/watcher/watcherfakes"
 	"github.com/rs/zerolog"
 
 	"github.com/stretchr/testify/require"

--- a/internal/watcher/watcherfakes/fake_activities.go
+++ b/internal/watcher/watcherfakes/fake_activities.go
@@ -4,7 +4,7 @@ package watcherfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/internal/watcher"
+	"github.com/dkyanakiev/vaul7y/internal/watcher"
 )
 
 type FakeActivities struct {

--- a/internal/watcher/watcherfakes/fake_vault.go
+++ b/internal/watcher/watcherfakes/fake_vault.go
@@ -4,8 +4,8 @@ package watcherfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/internal/watcher"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/watcher"
 	"github.com/hashicorp/vault/api"
 )
 
@@ -114,6 +114,57 @@ type FakeVault struct {
 	setNamespaceMutex       sync.RWMutex
 	setNamespaceArgsForCall []struct {
 		arg1 string
+	}
+	GetSecretDataStub        func(string, string) (*api.Secret, error)
+	getSecretDataMutex       sync.RWMutex
+	getSecretDataArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getSecretDataReturns struct {
+		result1 *api.Secret
+		result2 error
+	}
+	getSecretDataReturnsOnCall map[int]struct {
+		result1 *api.Secret
+		result2 error
+	}
+	GetSecretMetadataStub        func(string, string) (*models.Metadata, error)
+	getSecretMetadataMutex       sync.RWMutex
+	getSecretMetadataArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getSecretMetadataReturns struct {
+		result1 *models.Metadata
+		result2 error
+	}
+	getSecretMetadataReturnsOnCall map[int]struct {
+		result1 *models.Metadata
+		result2 error
+	}
+	ListAuthMethodsStub        func() (map[string]*models.AuthMethod, error)
+	listAuthMethodsMutex       sync.RWMutex
+	listAuthMethodsArgsForCall []struct{}
+	listAuthMethodsReturns     struct {
+		result1 map[string]*models.AuthMethod
+		result2 error
+	}
+	TokenInfoStub        func() (int64, []string, error)
+	tokenInfoMutex       sync.RWMutex
+	tokenInfoArgsForCall []struct{}
+	tokenInfoReturns     struct {
+		result1 int64
+		result2 []string
+		result3 error
+	}
+	SealStatusStub        func() (string, string, error)
+	sealStatusMutex       sync.RWMutex
+	sealStatusArgsForCall []struct{}
+	sealStatusReturns     struct {
+		result1 string
+		result2 string
+		result3 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -630,6 +681,201 @@ func (fake *FakeVault) SetNamespaceArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
+func (fake *FakeVault) GetSecretData(arg1 string, arg2 string) (*api.Secret, error) {
+	fake.getSecretDataMutex.Lock()
+	ret, specificReturn := fake.getSecretDataReturnsOnCall[len(fake.getSecretDataArgsForCall)]
+	fake.getSecretDataArgsForCall = append(fake.getSecretDataArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetSecretDataStub
+	fakeReturns := fake.getSecretDataReturns
+	fake.recordInvocation("GetSecretData", []interface{}{arg1, arg2})
+	fake.getSecretDataMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeVault) GetSecretDataCallCount() int {
+	fake.getSecretDataMutex.RLock()
+	defer fake.getSecretDataMutex.RUnlock()
+	return len(fake.getSecretDataArgsForCall)
+}
+
+func (fake *FakeVault) GetSecretDataCalls(stub func(string, string) (*api.Secret, error)) {
+	fake.getSecretDataMutex.Lock()
+	defer fake.getSecretDataMutex.Unlock()
+	fake.GetSecretDataStub = stub
+}
+
+func (fake *FakeVault) GetSecretDataArgsForCall(i int) (string, string) {
+	fake.getSecretDataMutex.RLock()
+	defer fake.getSecretDataMutex.RUnlock()
+	argsForCall := fake.getSecretDataArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeVault) GetSecretDataReturns(result1 *api.Secret, result2 error) {
+	fake.getSecretDataMutex.Lock()
+	defer fake.getSecretDataMutex.Unlock()
+	fake.GetSecretDataStub = nil
+	fake.getSecretDataReturns = struct {
+		result1 *api.Secret
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVault) GetSecretDataReturnsOnCall(i int, result1 *api.Secret, result2 error) {
+	fake.getSecretDataMutex.Lock()
+	defer fake.getSecretDataMutex.Unlock()
+	fake.GetSecretDataStub = nil
+	if fake.getSecretDataReturnsOnCall == nil {
+		fake.getSecretDataReturnsOnCall = make(map[int]struct {
+			result1 *api.Secret
+			result2 error
+		})
+	}
+	fake.getSecretDataReturnsOnCall[i] = struct {
+		result1 *api.Secret
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVault) GetSecretMetadata(arg1 string, arg2 string) (*models.Metadata, error) {
+	fake.getSecretMetadataMutex.Lock()
+	ret, specificReturn := fake.getSecretMetadataReturnsOnCall[len(fake.getSecretMetadataArgsForCall)]
+	fake.getSecretMetadataArgsForCall = append(fake.getSecretMetadataArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetSecretMetadataStub
+	fakeReturns := fake.getSecretMetadataReturns
+	fake.recordInvocation("GetSecretMetadata", []interface{}{arg1, arg2})
+	fake.getSecretMetadataMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeVault) GetSecretMetadataCallCount() int {
+	fake.getSecretMetadataMutex.RLock()
+	defer fake.getSecretMetadataMutex.RUnlock()
+	return len(fake.getSecretMetadataArgsForCall)
+}
+
+func (fake *FakeVault) GetSecretMetadataCalls(stub func(string, string) (*models.Metadata, error)) {
+	fake.getSecretMetadataMutex.Lock()
+	defer fake.getSecretMetadataMutex.Unlock()
+	fake.GetSecretMetadataStub = stub
+}
+
+func (fake *FakeVault) GetSecretMetadataArgsForCall(i int) (string, string) {
+	fake.getSecretMetadataMutex.RLock()
+	defer fake.getSecretMetadataMutex.RUnlock()
+	argsForCall := fake.getSecretMetadataArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeVault) GetSecretMetadataReturns(result1 *models.Metadata, result2 error) {
+	fake.getSecretMetadataMutex.Lock()
+	defer fake.getSecretMetadataMutex.Unlock()
+	fake.GetSecretMetadataStub = nil
+	fake.getSecretMetadataReturns = struct {
+		result1 *models.Metadata
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVault) GetSecretMetadataReturnsOnCall(i int, result1 *models.Metadata, result2 error) {
+	fake.getSecretMetadataMutex.Lock()
+	defer fake.getSecretMetadataMutex.Unlock()
+	fake.GetSecretMetadataStub = nil
+	if fake.getSecretMetadataReturnsOnCall == nil {
+		fake.getSecretMetadataReturnsOnCall = make(map[int]struct {
+			result1 *models.Metadata
+			result2 error
+		})
+	}
+	fake.getSecretMetadataReturnsOnCall[i] = struct {
+		result1 *models.Metadata
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVault) ListAuthMethods() (map[string]*models.AuthMethod, error) {
+	fake.listAuthMethodsMutex.Lock()
+	fake.listAuthMethodsArgsForCall = append(fake.listAuthMethodsArgsForCall, struct{}{})
+	fake.recordInvocation("ListAuthMethods", []interface{}{})
+	fake.listAuthMethodsMutex.Unlock()
+	if fake.ListAuthMethodsStub != nil {
+		return fake.ListAuthMethodsStub()
+	}
+	return fake.listAuthMethodsReturns.result1, fake.listAuthMethodsReturns.result2
+}
+
+func (fake *FakeVault) ListAuthMethodsReturns(result1 map[string]*models.AuthMethod, result2 error) {
+	fake.listAuthMethodsMutex.Lock()
+	defer fake.listAuthMethodsMutex.Unlock()
+	fake.ListAuthMethodsStub = nil
+	fake.listAuthMethodsReturns = struct {
+		result1 map[string]*models.AuthMethod
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVault) TokenInfo() (int64, []string, error) {
+	fake.tokenInfoMutex.Lock()
+	fake.tokenInfoArgsForCall = append(fake.tokenInfoArgsForCall, struct{}{})
+	fake.recordInvocation("TokenInfo", []interface{}{})
+	fake.tokenInfoMutex.Unlock()
+	if fake.TokenInfoStub != nil {
+		return fake.TokenInfoStub()
+	}
+	return fake.tokenInfoReturns.result1, fake.tokenInfoReturns.result2, fake.tokenInfoReturns.result3
+}
+
+func (fake *FakeVault) TokenInfoReturns(result1 int64, result2 []string, result3 error) {
+	fake.tokenInfoMutex.Lock()
+	defer fake.tokenInfoMutex.Unlock()
+	fake.TokenInfoStub = nil
+	fake.tokenInfoReturns = struct {
+		result1 int64
+		result2 []string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeVault) SealStatus() (string, string, error) {
+	fake.sealStatusMutex.Lock()
+	fake.sealStatusArgsForCall = append(fake.sealStatusArgsForCall, struct{}{})
+	fake.recordInvocation("SealStatus", []interface{}{})
+	fake.sealStatusMutex.Unlock()
+	if fake.SealStatusStub != nil {
+		return fake.SealStatusStub()
+	}
+	return fake.sealStatusReturns.result1, fake.sealStatusReturns.result2, fake.sealStatusReturns.result3
+}
+
+func (fake *FakeVault) SealStatusReturns(result1, result2 string, result3 error) {
+	fake.sealStatusMutex.Lock()
+	defer fake.sealStatusMutex.Unlock()
+	fake.SealStatusStub = nil
+	fake.sealStatusReturns = struct {
+		result1 string
+		result2 string
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeVault) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -651,6 +897,10 @@ func (fake *FakeVault) Invocations() map[string][][]interface{} {
 	defer fake.listSecretsMutex.RUnlock()
 	fake.setNamespaceMutex.RLock()
 	defer fake.setNamespaceMutex.RUnlock()
+	fake.getSecretDataMutex.RLock()
+	defer fake.getSecretDataMutex.RUnlock()
+	fake.getSecretMetadataMutex.RLock()
+	defer fake.getSecretMetadataMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/tui/component/auth_table.go
+++ b/tui/component/auth_table.go
@@ -1,0 +1,77 @@
+package component
+
+import (
+	"sort"
+
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const TableTitleAuth = "Auth Methods"
+
+var AuthTableHeaders = []string{"Path", "Type", "Description"}
+
+type AuthTable struct {
+	Table Table
+	Props *AuthTableProps
+
+	slot *tview.Flex
+}
+
+type AuthTableProps struct {
+	Data              map[string]*models.AuthMethod
+	HandleNoResources models.HandlerFunc
+}
+
+func NewAuthTable() *AuthTable {
+	t := primitive.NewTable()
+	return &AuthTable{
+		Table: t,
+		Props: &AuthTableProps{},
+	}
+}
+
+func (a *AuthTable) Bind(slot *tview.Flex) {
+	a.slot = slot
+}
+
+func (a *AuthTable) Render() error {
+	a.reset()
+	a.Table.SetTitle("%s", TableTitleAuth)
+
+	if len(a.Props.Data) == 0 {
+		a.Props.HandleNoResources(
+			"%sno auth methods available\n¯%s\\_( ͡• ͜ʖ ͡•)_/¯",
+			styles.HighlightPrimaryTag,
+			styles.HighlightSecondaryTag,
+		)
+		return nil
+	}
+
+	a.Table.RenderHeader(AuthTableHeaders)
+	a.renderRows()
+	a.slot.AddItem(a.Table.Primitive(), 0, 1, false)
+	return nil
+}
+
+func (a *AuthTable) reset() {
+	a.slot.Clear()
+	a.Table.Clear()
+}
+
+func (a *AuthTable) renderRows() {
+	keys := make([]string, 0, len(a.Props.Data))
+	for k := range a.Props.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for i, k := range keys {
+		m := a.Props.Data[k]
+		row := []string{k, m.Type, m.Description}
+		a.Table.RenderRow(row, i+1, tcell.ColorWhite)
+	}
+}

--- a/tui/component/commands.go
+++ b/tui/component/commands.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rivo/tview"
 
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 )
 
 var (
@@ -16,6 +16,7 @@ var (
 		fmt.Sprintf("%sctrl-b%s to display Secret Engines", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sctrl-p%s to display ACL Policies", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sctrl-t%s to display Namespaces", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sctrl-a%s to display Auth Methods", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sctrl-c%s to Quit", styles.HighlightPrimaryTag, styles.StandardColorTag),
 	}
 	MountsCommands = []string{
@@ -30,28 +31,44 @@ var (
 	}
 	PolicyACLCommands = []string{
 		fmt.Sprintf("\n%s ACL Policy Commands:", styles.HighlightSecondaryTag),
+		fmt.Sprintf("%sj/k%s scroll line down/up", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sd/u%s scroll half-page down/up", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sg/G%s jump to top/bottom", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sE%s to edit policy", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sc%s copy policy to clipboard", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sw%s toggle word wrap", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sesc%s to go back", styles.HighlightPrimaryTag, styles.StandardColorTag),
-		// fmt.Sprintf("%s</>%s apply filter", styles.HighlightPrimaryTag, styles.StandardColorTag),
+	}
+	PolicyACLEditCommands = []string{
+		fmt.Sprintf("\n%s ACL Policy Edit:", styles.HighlightSecondaryTag),
+		fmt.Sprintf("%sctrl-w%s to save policy", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sesc%s to cancel edit", styles.HighlightPrimaryTag, styles.StandardColorTag),
 	}
 	SecretsCommands = []string{
 		fmt.Sprintf("\n%s Secrets Commands:", styles.HighlightSecondaryTag),
 		fmt.Sprintf("%se or enter%s to navigate to selected the path", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sb or esc%s to go back to the previous path", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sctrl-n%s to Create a new secret ", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sJ%s to jump to a specific path", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s/%s Filter objects ", styles.HighlightPrimaryTag, styles.StandardColorTag),
 	}
 	SecretObjectCommands = []string{
 		fmt.Sprintf("\n%s Secret Commands:", styles.HighlightSecondaryTag),
 		fmt.Sprintf("%sh%s toggle display for secrets", styles.HighlightPrimaryTag, styles.StandardColorTag),
-		fmt.Sprintf("%st%s toggle display for metadata info", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%st%s toggle metadata panel (v2 only)", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sc%s copy secret to clipboard", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sj%s toggle json view for secret", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sP%s to PATCH secret", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sU%s to UPDATE secret", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sD%s delete current version (v2: soft, v1: permanent)", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sR%s rollback to a previous version (v2 only)", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sX%s permanently destroy a version (v2 only)", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sM%s edit secret metadata (v2 only)", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sb or esc%s to go back to the previous path", styles.HighlightPrimaryTag, styles.StandardColorTag),
 	}
 	SecretsObjectPatchCommands = []string{
 		fmt.Sprintf("\n%s Secret Commands:", styles.HighlightSecondaryTag),
+		fmt.Sprintf("%sctrl-v%s to paste from clipboard", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sctrl-w%s to submit your PATCH/UPDATE request", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sesc%s to go back to the previous path", styles.HighlightPrimaryTag, styles.StandardColorTag),
 	}
@@ -59,6 +76,10 @@ var (
 		fmt.Sprintf("\n%s Namespace Commands:", styles.HighlightSecondaryTag),
 		fmt.Sprintf("%sctrl-d%s to back to default namespace", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sctrl-w%s to back to root namespace", styles.HighlightPrimaryTag, styles.StandardColorTag),
+	}
+	AuthCommands = []string{
+		fmt.Sprintf("\n%s Auth Method Commands:", styles.HighlightSecondaryTag),
+		fmt.Sprintf("%sesc%s to go back", styles.HighlightPrimaryTag, styles.StandardColorTag),
 	}
 )
 

--- a/tui/component/commands_test.go
+++ b/tui/component/commands_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/tui/component/componentfakes/fake_box.go
+++ b/tui/component/componentfakes/fake_box.go
@@ -4,7 +4,7 @@ package componentfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	tcell "github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )

--- a/tui/component/componentfakes/fake_done_modal_func.go
+++ b/tui/component/componentfakes/fake_done_modal_func.go
@@ -4,7 +4,7 @@ package componentfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 )
 
 type FakeDoneModalFunc struct {

--- a/tui/component/componentfakes/fake_drop_down.go
+++ b/tui/component/componentfakes/fake_drop_down.go
@@ -4,7 +4,7 @@ package componentfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/rivo/tview"
 )
 

--- a/tui/component/componentfakes/fake_input_field.go
+++ b/tui/component/componentfakes/fake_input_field.go
@@ -4,7 +4,7 @@ package componentfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	tcell "github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -48,6 +48,11 @@ type FakeInputField struct {
 	SetTextStub        func(string)
 	setTextMutex       sync.RWMutex
 	setTextArgsForCall []struct {
+		arg1 string
+	}
+	SetLabelStub        func(string)
+	setLabelMutex       sync.RWMutex
+	setLabelArgsForCall []struct {
 		arg1 string
 	}
 	invocations      map[string][][]interface{}
@@ -286,6 +291,16 @@ func (fake *FakeInputField) SetTextArgsForCall(i int) string {
 	defer fake.setTextMutex.RUnlock()
 	argsForCall := fake.setTextArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeInputField) SetLabel(arg1 string) {
+	fake.setLabelMutex.Lock()
+	fake.setLabelArgsForCall = append(fake.setLabelArgsForCall, struct{ arg1 string }{arg1})
+	fake.recordInvocation("SetLabel", []interface{}{arg1})
+	fake.setLabelMutex.Unlock()
+	if fake.SetLabelStub != nil {
+		fake.SetLabelStub(arg1)
+	}
 }
 
 func (fake *FakeInputField) Invocations() map[string][][]interface{} {

--- a/tui/component/componentfakes/fake_modal.go
+++ b/tui/component/componentfakes/fake_modal.go
@@ -4,7 +4,7 @@ package componentfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/rivo/tview"
 )
 

--- a/tui/component/componentfakes/fake_selector.go
+++ b/tui/component/componentfakes/fake_selector.go
@@ -4,8 +4,8 @@ package componentfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/rivo/tview"
 )
 

--- a/tui/component/componentfakes/fake_table.go
+++ b/tui/component/componentfakes/fake_table.go
@@ -4,7 +4,7 @@ package componentfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	tcell "github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -85,6 +85,17 @@ type FakeTable struct {
 	setTitleArgsForCall []struct {
 		arg1 string
 		arg2 []interface{}
+	}
+	SetSelectableStub        func(bool, bool)
+	setSelectableMutex       sync.RWMutex
+	setSelectableArgsForCall []struct {
+		arg1 bool
+		arg2 bool
+	}
+	SetSelectedStyleStub        func(tcell.Style)
+	setSelectedStyleMutex       sync.RWMutex
+	setSelectedStyleArgsForCall []struct {
+		arg1 tcell.Style
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -511,6 +522,71 @@ func (fake *FakeTable) SetTitleArgsForCall(i int) (string, []interface{}) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
+func (fake *FakeTable) SetSelectable(arg1 bool, arg2 bool) {
+	fake.setSelectableMutex.Lock()
+	fake.setSelectableArgsForCall = append(fake.setSelectableArgsForCall, struct {
+		arg1 bool
+		arg2 bool
+	}{arg1, arg2})
+	stub := fake.SetSelectableStub
+	fake.recordInvocation("SetSelectable", []interface{}{arg1, arg2})
+	fake.setSelectableMutex.Unlock()
+	if stub != nil {
+		fake.SetSelectableStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeTable) SetSelectableCallCount() int {
+	fake.setSelectableMutex.RLock()
+	defer fake.setSelectableMutex.RUnlock()
+	return len(fake.setSelectableArgsForCall)
+}
+
+func (fake *FakeTable) SetSelectableCalls(stub func(bool, bool)) {
+	fake.setSelectableMutex.Lock()
+	defer fake.setSelectableMutex.Unlock()
+	fake.SetSelectableStub = stub
+}
+
+func (fake *FakeTable) SetSelectableArgsForCall(i int) (bool, bool) {
+	fake.setSelectableMutex.RLock()
+	defer fake.setSelectableMutex.RUnlock()
+	argsForCall := fake.setSelectableArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeTable) SetSelectedStyle(arg1 tcell.Style) {
+	fake.setSelectedStyleMutex.Lock()
+	fake.setSelectedStyleArgsForCall = append(fake.setSelectedStyleArgsForCall, struct {
+		arg1 tcell.Style
+	}{arg1})
+	stub := fake.SetSelectedStyleStub
+	fake.recordInvocation("SetSelectedStyle", []interface{}{arg1})
+	fake.setSelectedStyleMutex.Unlock()
+	if stub != nil {
+		fake.SetSelectedStyleStub(arg1)
+	}
+}
+
+func (fake *FakeTable) SetSelectedStyleCallCount() int {
+	fake.setSelectedStyleMutex.RLock()
+	defer fake.setSelectedStyleMutex.RUnlock()
+	return len(fake.setSelectedStyleArgsForCall)
+}
+
+func (fake *FakeTable) SetSelectedStyleCalls(stub func(tcell.Style)) {
+	fake.setSelectedStyleMutex.Lock()
+	defer fake.setSelectedStyleMutex.Unlock()
+	fake.SetSelectedStyleStub = stub
+}
+
+func (fake *FakeTable) SetSelectedStyleArgsForCall(i int) tcell.Style {
+	fake.setSelectedStyleMutex.RLock()
+	defer fake.setSelectedStyleMutex.RUnlock()
+	argsForCall := fake.setSelectedStyleArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeTable) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -534,6 +610,10 @@ func (fake *FakeTable) Invocations() map[string][][]interface{} {
 	defer fake.setSelectedFuncMutex.RUnlock()
 	fake.setTitleMutex.RLock()
 	defer fake.setTitleMutex.RUnlock()
+	fake.setSelectableMutex.RLock()
+	defer fake.setSelectableMutex.RUnlock()
+	fake.setSelectedStyleMutex.RLock()
+	defer fake.setSelectedStyleMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/tui/component/componentfakes/fake_text_area.go
+++ b/tui/component/componentfakes/fake_text_area.go
@@ -4,7 +4,7 @@ package componentfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	tcell "github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -50,6 +50,17 @@ type FakeTextArea struct {
 		result1 *tview.TextArea
 	}
 	setTextReturnsOnCall map[int]struct {
+		result1 *tview.TextArea
+	}
+	SetChangedFuncStub        func(func()) *tview.TextArea
+	setChangedFuncMutex       sync.RWMutex
+	setChangedFuncArgsForCall []struct {
+		arg1 func()
+	}
+	setChangedFuncReturns struct {
+		result1 *tview.TextArea
+	}
+	setChangedFuncReturnsOnCall map[int]struct {
 		result1 *tview.TextArea
 	}
 	SetTitleStub        func(string)
@@ -306,6 +317,67 @@ func (fake *FakeTextArea) SetTitle(arg1 string) {
 	}
 }
 
+func (fake *FakeTextArea) SetChangedFunc(arg1 func()) *tview.TextArea {
+	fake.setChangedFuncMutex.Lock()
+	ret, specificReturn := fake.setChangedFuncReturnsOnCall[len(fake.setChangedFuncArgsForCall)]
+	fake.setChangedFuncArgsForCall = append(fake.setChangedFuncArgsForCall, struct {
+		arg1 func()
+	}{arg1})
+	stub := fake.SetChangedFuncStub
+	fakeReturns := fake.setChangedFuncReturns
+	fake.recordInvocation("SetChangedFunc", []interface{}{arg1})
+	fake.setChangedFuncMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeTextArea) SetChangedFuncCallCount() int {
+	fake.setChangedFuncMutex.RLock()
+	defer fake.setChangedFuncMutex.RUnlock()
+	return len(fake.setChangedFuncArgsForCall)
+}
+
+func (fake *FakeTextArea) SetChangedFuncCalls(stub func(func()) *tview.TextArea) {
+	fake.setChangedFuncMutex.Lock()
+	defer fake.setChangedFuncMutex.Unlock()
+	fake.SetChangedFuncStub = stub
+}
+
+func (fake *FakeTextArea) SetChangedFuncArgsForCall(i int) func() {
+	fake.setChangedFuncMutex.RLock()
+	defer fake.setChangedFuncMutex.RUnlock()
+	argsForCall := fake.setChangedFuncArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTextArea) SetChangedFuncReturns(result1 *tview.TextArea) {
+	fake.setChangedFuncMutex.Lock()
+	defer fake.setChangedFuncMutex.Unlock()
+	fake.SetChangedFuncStub = nil
+	fake.setChangedFuncReturns = struct {
+		result1 *tview.TextArea
+	}{result1}
+}
+
+func (fake *FakeTextArea) SetChangedFuncReturnsOnCall(i int, result1 *tview.TextArea) {
+	fake.setChangedFuncMutex.Lock()
+	defer fake.setChangedFuncMutex.Unlock()
+	fake.SetChangedFuncStub = nil
+	if fake.setChangedFuncReturnsOnCall == nil {
+		fake.setChangedFuncReturnsOnCall = make(map[int]struct {
+			result1 *tview.TextArea
+		})
+	}
+	fake.setChangedFuncReturnsOnCall[i] = struct {
+		result1 *tview.TextArea
+	}{result1}
+}
+
 func (fake *FakeTextArea) SetTitleCallCount() int {
 	fake.setTitleMutex.RLock()
 	defer fake.setTitleMutex.RUnlock()
@@ -336,6 +408,8 @@ func (fake *FakeTextArea) Invocations() map[string][][]interface{} {
 	defer fake.setBorderMutex.RUnlock()
 	fake.setBorderColorMutex.RLock()
 	defer fake.setBorderColorMutex.RUnlock()
+	fake.setChangedFuncMutex.RLock()
+	defer fake.setChangedFuncMutex.RUnlock()
 	fake.setTextMutex.RLock()
 	defer fake.setTextMutex.RUnlock()
 	fake.setTitleMutex.RLock()

--- a/tui/component/componentfakes/fake_text_view.go
+++ b/tui/component/componentfakes/fake_text_view.go
@@ -4,7 +4,7 @@ package componentfakes
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/rivo/tview"
 )
 

--- a/tui/component/components.go
+++ b/tui/component/components.go
@@ -1,8 +1,8 @@
 package component
 
 import (
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/tui/primitives"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -69,6 +69,7 @@ type Form interface {
 //go:generate counterfeiter . InputField
 type InputField interface {
 	Primitive
+	SetLabel(label string)
 	SetDoneFunc(handler func(k tcell.Key))
 	SetChangedFunc(handler func(text string))
 	SetAutocompleteFunc(callback func(currentText string) (entries []string))
@@ -99,6 +100,7 @@ type TextArea interface {
 	SetBorder(bool)
 	SetTitle(string)
 	SetBorderColor(tcell.Color)
+	SetChangedFunc(func()) *tview.TextArea
 }
 
 //go:generate counterfeiter . Box

--- a/tui/component/confirm.go
+++ b/tui/component/confirm.go
@@ -1,0 +1,52 @@
+package component
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+)
+
+const PageNameConfirm = "confirm"
+
+type Confirm struct {
+	Modal Modal
+	Props *ConfirmProps
+	pages *tview.Pages
+}
+
+type ConfirmProps struct {
+	Done DoneModalFunc
+}
+
+func NewConfirm() *Confirm {
+	buttons := []string{"Yes", "Cancel"}
+	modal := primitive.NewModal("Confirm", buttons, tcell.ColorDarkOliveGreen)
+	return &Confirm{
+		Modal: modal,
+		Props: &ConfirmProps{},
+	}
+}
+
+func (c *Confirm) Render(msg string) error {
+	if c.Props.Done == nil {
+		return ErrComponentPropsNotSet
+	}
+	if c.pages == nil {
+		return ErrComponentNotBound
+	}
+	c.Modal.SetDoneFunc(c.Props.Done)
+	c.Modal.SetText(msg)
+	c.pages.AddPage(PageNameConfirm, c.Modal.Container(), true, true)
+	return nil
+}
+
+// FocusPrimitive returns the actual modal primitive that must receive focus.
+// Call v.Layout.Container.SetFocus(confirm.FocusPrimitive()) immediately after Render.
+func (c *Confirm) FocusPrimitive() tview.Primitive {
+	return c.Modal.Primitive()
+}
+
+func (c *Confirm) Bind(pages *tview.Pages) {
+	c.pages = pages
+}

--- a/tui/component/error.go
+++ b/tui/component/error.go
@@ -4,7 +4,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
 )
 
 const PageNameError = "error"

--- a/tui/component/error_test.go
+++ b/tui/component/error_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"
 )

--- a/tui/component/info.go
+++ b/tui/component/info.go
@@ -3,8 +3,8 @@ package component
 import (
 	"github.com/rivo/tview"
 
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 )
 
 const PageNameInfo = "info"

--- a/tui/component/info_test.go
+++ b/tui/component/info_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"
 )

--- a/tui/component/jump.go
+++ b/tui/component/jump.go
@@ -1,7 +1,7 @@
 package component
 
 import (
-	"github.com/dkyanakiev/vaulty/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )

--- a/tui/component/logo.go
+++ b/tui/component/logo.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/rivo/tview"
 )
 

--- a/tui/component/logo_test.go
+++ b/tui/component/logo_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"
 )

--- a/tui/component/mounts_table.go
+++ b/tui/component/mounts_table.go
@@ -5,9 +5,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog"

--- a/tui/component/mounts_table_test.go
+++ b/tui/component/mounts_table_test.go
@@ -3,10 +3,10 @@ package component_test
 import (
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"

--- a/tui/component/namespace_table.go
+++ b/tui/component/namespace_table.go
@@ -5,9 +5,9 @@ import (
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 )
 
 const TableTitleNamespaces = "Namespaces"

--- a/tui/component/policy_acl_table.go
+++ b/tui/component/policy_acl_table.go
@@ -1,9 +1,11 @@
 package component
 
 import (
-	"github.com/dkyanakiev/vaulty/internal/models"
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"sync"
+
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/rivo/tview"
 )
 
@@ -17,10 +19,55 @@ type SelectPolicyACLFunc func(policyName string)
 
 type PolicyAclTable struct {
 	TextView TextView
+	TextArea TextArea
 	Props    *PolicyAclTableProps
 	Flex     *tview.Flex
+	editable bool
+	wordWrap bool
+	editMu   sync.RWMutex
 
 	slot *tview.Flex
+}
+
+const ScrollHalfPage = 15
+
+func (p *PolicyAclTable) ToggleWrap() {
+	p.wordWrap = !p.wordWrap
+	wrap := p.wordWrap
+	p.TextView.ModifyPrimitive(func(tv *tview.TextView) {
+		tv.SetWrap(wrap)
+		tv.SetWordWrap(wrap)
+	})
+}
+
+func (p *PolicyAclTable) ScrollDown(lines int) {
+	p.TextView.ModifyPrimitive(func(tv *tview.TextView) {
+		row, col := tv.GetScrollOffset()
+		tv.ScrollTo(row+lines, col)
+	})
+}
+
+func (p *PolicyAclTable) ScrollUp(lines int) {
+	p.TextView.ModifyPrimitive(func(tv *tview.TextView) {
+		row, col := tv.GetScrollOffset()
+		if newRow := row - lines; newRow > 0 {
+			tv.ScrollTo(newRow, col)
+		} else {
+			tv.ScrollTo(0, col)
+		}
+	})
+}
+
+func (p *PolicyAclTable) IsEditable() bool {
+	p.editMu.RLock()
+	defer p.editMu.RUnlock()
+	return p.editable
+}
+
+func (p *PolicyAclTable) SetEditable(val bool) {
+	p.editMu.Lock()
+	defer p.editMu.Unlock()
+	p.editable = val
 }
 
 type PolicyAclTableProps struct {
@@ -39,15 +86,25 @@ func NewPolicyAclTable() *PolicyAclTable {
 	t.SetTextAlign(tview.AlignLeft)
 	t.SetBorderColor(styles.TcellColorStandard)
 	t.SetBorder(true)
+	t.ModifyPrimitive(func(tv *tview.TextView) {
+		tv.SetWrap(true)
+		tv.SetWordWrap(true)
+		tv.SetScrollable(true)
+	})
+
+	ta := primitive.NewTextArea()
+	ta.SetBorder(true)
+	ta.SetBorderColor(styles.TcellColorStandard)
 
 	flex := tview.NewFlex().
-		//(t, 0, 1, true).
 		AddItem(tview.NewBox(), 0, 1, false)
 
 	pt := &PolicyAclTable{
 		Flex:     flex,
 		TextView: t,
+		TextArea: ta,
 		Props:    &PolicyAclTableProps{},
+		wordWrap: true,
 	}
 
 	return pt
@@ -83,4 +140,11 @@ func (p *PolicyAclTable) Render() error {
 func (p *PolicyAclTable) renderACL() {
 	p.TextView.SetTitle(p.Props.SelectedPolicyName)
 	p.TextView.SetText(p.Props.SelectedPolicyACL)
+}
+
+func (p *PolicyAclTable) RenderEditArea() {
+	p.reset()
+	p.TextArea.SetTitle(p.Props.SelectedPolicyName + " [EDITING]")
+	p.TextArea.SetText(p.Props.SelectedPolicyACL, true)
+	p.slot.AddItem(p.TextArea.Primitive(), 0, 1, true)
 }

--- a/tui/component/policy_acl_table_test.go
+++ b/tui/component/policy_acl_table_test.go
@@ -3,9 +3,9 @@ package component_test
 import (
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"
 )

--- a/tui/component/policy_acl_table_test.go
+++ b/tui/component/policy_acl_table_test.go
@@ -70,3 +70,62 @@ func TestPolicyACLTable_Pass(t *testing.T) {
 
 func TestPolicyACLTable_Fail(t *testing.T) {
 }
+
+func TestPolicyAclTable_Scroll(t *testing.T) {
+	// Helpers wire up a real tview.TextView through the FakeTextView stub so
+	// the closure inside ScrollDown/ScrollUp operates on real in-memory state.
+	makeTable := func(initialRow int) (*component.PolicyAclTable, *tview.TextView) {
+		fakeTV := &componentfakes.FakeTextView{}
+		realTV := tview.NewTextView()
+		realTV.ScrollTo(initialRow, 0)
+		fakeTV.ModifyPrimitiveStub = func(fn func(*tview.TextView)) { fn(realTV) }
+
+		pt := component.NewPolicyAclTable()
+		pt.TextView = fakeTV
+		return pt, realTV
+	}
+
+	t.Run("ScrollDown increases row offset", func(t *testing.T) {
+		pt, realTV := makeTable(10)
+		pt.ScrollDown(5)
+		row, col := realTV.GetScrollOffset()
+		require.Equal(t, 15, row)
+		require.Equal(t, 0, col)
+	})
+
+	t.Run("ScrollDown from zero", func(t *testing.T) {
+		pt, realTV := makeTable(0)
+		pt.ScrollDown(3)
+		row, _ := realTV.GetScrollOffset()
+		require.Equal(t, 3, row)
+	})
+
+	t.Run("ScrollUp decreases row offset", func(t *testing.T) {
+		pt, realTV := makeTable(10)
+		pt.ScrollUp(3)
+		row, col := realTV.GetScrollOffset()
+		require.Equal(t, 7, row)
+		require.Equal(t, 0, col)
+	})
+
+	t.Run("ScrollUp clamps to zero when delta exceeds offset", func(t *testing.T) {
+		pt, realTV := makeTable(3)
+		pt.ScrollUp(10)
+		row, _ := realTV.GetScrollOffset()
+		require.Equal(t, 0, row)
+	})
+
+	t.Run("ScrollUp from zero stays at zero", func(t *testing.T) {
+		pt, realTV := makeTable(0)
+		pt.ScrollUp(5)
+		row, _ := realTV.GetScrollOffset()
+		require.Equal(t, 0, row)
+	})
+
+	t.Run("ScrollUp exact delta lands on zero", func(t *testing.T) {
+		pt, realTV := makeTable(5)
+		pt.ScrollUp(5)
+		row, _ := realTV.GetScrollOffset()
+		require.Equal(t, 0, row)
+	})
+}

--- a/tui/component/policy_table.go
+++ b/tui/component/policy_table.go
@@ -1,9 +1,9 @@
 package component
 
 import (
-	"github.com/dkyanakiev/vaulty/internal/models"
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )

--- a/tui/component/policy_table_test.go
+++ b/tui/component/policy_table_test.go
@@ -3,9 +3,9 @@ package component_test
 import (
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"

--- a/tui/component/search.go
+++ b/tui/component/search.go
@@ -3,7 +3,7 @@ package component
 import (
 	"fmt"
 
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/rivo/tview"
 )
 

--- a/tui/component/search_test.go
+++ b/tui/component/search_test.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"

--- a/tui/component/secret_obj_table.go
+++ b/tui/component/secret_obj_table.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"sync"
 	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/hashicorp/vault/api"
 	"github.com/rivo/tview"
@@ -28,6 +29,7 @@ var (
 	SecretObjTableHeaderJson = []string{
 		"Json",
 	}
+	SecretObjTableHeaderVersions = []string{"Version", "Status", "Created"}
 )
 
 type SelectSecretPathFunc func(jsonPath string)
@@ -36,6 +38,7 @@ type SecretObjTable struct {
 	Table               Table
 	MetadataTable       Table
 	CustomMetadataTable Table
+	VersionHistoryTable Table
 	TextView            TextView
 	TextArea            TextArea
 	Props               *SecretObjTableProps
@@ -43,8 +46,21 @@ type SecretObjTable struct {
 	ShowJson            bool
 	ShowMetadata        bool
 	Editable            bool
+	editMu              sync.RWMutex
 	CursorPosition      int
 	slot                *tview.Flex
+}
+
+func (s *SecretObjTable) IsEditable() bool {
+	s.editMu.RLock()
+	defer s.editMu.RUnlock()
+	return s.Editable
+}
+
+func (s *SecretObjTable) SetEditable(val bool) {
+	s.editMu.Lock()
+	defer s.editMu.Unlock()
+	s.Editable = val
 }
 
 type SecretObjTableProps struct {
@@ -69,6 +85,7 @@ func NewSecretObjTable() *SecretObjTable {
 	t := primitive.NewTable()
 	mt := primitive.NewTable()
 	cmtt := primitive.NewTable()
+	vht := primitive.NewTable()
 	tv := primitive.NewTextView(1)
 	tv.SetTextAlign(tview.AlignLeft)
 	tv.SetBorderColor(styles.TcellColorStandard)
@@ -76,19 +93,22 @@ func NewSecretObjTable() *SecretObjTable {
 
 	mt.SetSelectable(false, false)
 	cmtt.SetSelectable(false, false)
+	vht.SetSelectable(false, false)
+	nop := zerolog.Nop()
 	jt := &SecretObjTable{
 		Table:               t,
 		MetadataTable:       mt,
 		CustomMetadataTable: cmtt,
+		VersionHistoryTable: vht,
 		TextView:            tv,
 		TextArea:            ta,
 		Props:               &SecretObjTableProps{},
+		Logger:              &nop,
 		ShowJson:            false,
 		ShowMetadata:        false,
 		Editable:            false,
 		slot:                tview.NewFlex(),
 	}
-	//TODO: Revisit
 	jt.slot.AddItem(jt.TextView.Primitive(), 0, 1, false)
 	return jt
 }
@@ -102,13 +122,24 @@ func (s *SecretObjTable) reset() {
 	s.Table.Clear()
 	s.MetadataTable.Clear()
 	s.CustomMetadataTable.Clear()
+	s.VersionHistoryTable.Clear()
+	s.TextView.Clear()
+}
+
+// clearDataTables clears only data rows without touching the slot layout.
+// Used to refresh a split view in-place.
+func (s *SecretObjTable) clearDataTables() {
+	s.Table.Clear()
+	s.MetadataTable.Clear()
+	s.CustomMetadataTable.Clear()
+	s.VersionHistoryTable.Clear()
 	s.TextView.Clear()
 }
 
 func (s *SecretObjTable) ToggleView() {
 	s.slot.Clear()
 	if !s.ShowMetadata {
-		if !s.Editable {
+		if !s.IsEditable() {
 			if s.Props.JsonOnly {
 				s.slot.AddItem(s.TextView.Primitive(), 0, 1, true)
 				s.renderJson()
@@ -137,11 +168,33 @@ func (s *SecretObjTable) ToggleView() {
 func (s *SecretObjTable) ToggleMetaView() {
 	s.Logger.Debug().Msgf("ShowMetadata: %v", s.ShowMetadata)
 	if s.ShowMetadata {
-		s.slot.AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-			AddItem(s.MetadataTable.Primitive(), 10, 1, false).
-			AddItem(s.CustomMetadataTable.Primitive(), 0, 1, false), 0, 2, false)
+		s.slot.Clear()
+
+		// Left panel: normal secret content (table or JSON).
+		var mainContent tview.Primitive
+		if s.Props.JsonOnly || s.ShowJson {
+			s.renderJson()
+			mainContent = s.TextView.Primitive()
+		} else {
+			s.Table.SetTitle("%s %s", SecretObjTableTitle, s.Props.SelectedPath)
+			s.Table.RenderHeader(SecretObjTableHeaderJobs)
+			s.renderRows()
+			mainContent = s.Table.Primitive()
+		}
+
+		// Right panel: metadata / custom-metadata / version-history stacked vertically.
+		metaPanel := tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(s.MetadataTable.Primitive(), 10, 0, false).
+			AddItem(s.CustomMetadataTable.Primitive(), 5, 0, false).
+			AddItem(s.VersionHistoryTable.Primitive(), 0, 1, false)
+
+		s.slot.SetDirection(tview.FlexColumn).
+			AddItem(mainContent, 0, 2, true).
+			AddItem(metaPanel, 0, 1, false)
+
 		s.renderMetadata()
 	} else {
+		s.slot.SetDirection(tview.FlexRow)
 		s.Render()
 	}
 }
@@ -159,72 +212,124 @@ func (s *SecretObjTable) GetIDForSelection() (string, string) {
 }
 
 func (s *SecretObjTable) Render() error {
-	if !s.ShowMetadata {
-		s.Props.MissingSecret = false
-		s.Props.JsonOnly = false
-		s.reset()
-		s.Table.SetTitle("%s %s", SecretObjTableTitle, s.Props.SelectedPath)
+	// When the split view is active, refresh data in-place without rebuilding
+	// the slot layout (which would destroy the split).
+	if s.ShowMetadata {
+		s.clearDataTables()
 		s.validationLogic()
-
-		if s.Props.MissingSecret {
-			s.Props.HandleNoResources(
-				"%sno Secret Object data available\n¯%s\\_( ͡• ͜ʖ ͡•)_/¯",
-				styles.HighlightPrimaryTag,
-				styles.HighlightSecondaryTag,
-			)
-			return nil
-		}
-
-		s.Table.SetSelectedFunc(s.pathSelected)
-		s.Table.RenderHeader(SecretObjTableHeaderJobs)
-
 		if !s.Props.MissingSecret {
-			s.ToggleView()
+			if s.Props.JsonOnly || s.ShowJson {
+				s.renderJson()
+			} else {
+				s.Table.SetTitle("%s %s", SecretObjTableTitle, s.Props.SelectedPath)
+				s.Table.RenderHeader(SecretObjTableHeaderJobs)
+				s.renderRows()
+			}
 		}
-
+		s.renderMetadata()
+		return nil
 	}
-	return nil
-}
 
-func (s *SecretObjTable) renderMetadata() error {
-	if s.Props.Metadata == nil {
+	s.Props.MissingSecret = false
+	s.Props.JsonOnly = false
+	s.reset()
+	s.Table.SetTitle("%s %s", SecretObjTableTitle, s.Props.SelectedPath)
+	s.validationLogic()
+
+	if s.Props.MissingSecret {
 		s.Props.HandleNoResources(
-			"%sno Secret Object data available\n¯%s\\_( ͡• ͜ʖ ͡•)_/¯",
+			"%sno Secret Object data available\n¯%s\\_( ͡• ͜ʖ ͡•)_/¯",
 			styles.HighlightPrimaryTag,
 			styles.HighlightSecondaryTag,
 		)
 		return nil
 	}
 
-	s.MetadataTable.SetTitle("Metadata")
-	s.CustomMetadataTable.SetTitle("Custom Metadata")
-	s.MetadataTable.RenderRow([]string{"Created Time", ConvertTimeFormat(s.Props.Metadata.CreatedTime)}, 0, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Update Time", ConvertTimeFormat(s.Props.Metadata.UpdatedTime)}, 1, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Current Version", strconv.Itoa(s.Props.Metadata.CurrentVersion)}, 2, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Oldest Version", strconv.Itoa(s.Props.Metadata.CurrentVersion)}, 3, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Delete after version", s.Props.Metadata.DeleteVersionAfter}, 4, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Cas Required", strconv.FormatBool(s.Props.Metadata.CasRequired)}, 5, tcell.ColorYellow)
+	s.Table.SetSelectedFunc(s.pathSelected)
+	s.Table.RenderHeader(SecretObjTableHeaderJobs)
 
-	i := 0
-	for k, v := range s.Props.Metadata.CustomMetadata {
-		value, ok := v.(string)
-		if !ok {
-			// handle the case where v is not a string
-			continue
-		}
-		row := []string{
-			k,
-			value,
-		}
-		s.CustomMetadataTable.RenderRow(row, i, tcell.ColorYellow)
-		i++
+	if !s.Props.MissingSecret {
+		s.ToggleView()
 	}
 
 	return nil
 }
 
-func (s *SecretObjTable) renderRows() {
+func (s *SecretObjTable) renderMetadata() error {
+	if s.Props.Metadata == nil {
+		return nil
+	}
 
+	deleteAfter := s.Props.Metadata.DeleteVersionAfter
+	if deleteAfter == "" || deleteAfter == "0s" {
+		deleteAfter = "Never"
+	}
+
+	s.MetadataTable.SetTitle("Secret Metadata")
+	s.MetadataTable.RenderRow([]string{"Updated Time", ConvertTimeFormat(s.Props.Metadata.UpdatedTime)}, 0, tcell.ColorYellow)
+	s.MetadataTable.RenderRow([]string{"Created Time", ConvertTimeFormat(s.Props.Metadata.CreatedTime)}, 1, tcell.ColorYellow)
+	s.MetadataTable.RenderRow([]string{"Current Version", strconv.Itoa(s.Props.Metadata.CurrentVersion)}, 2, tcell.ColorYellow)
+	s.MetadataTable.RenderRow([]string{"Oldest Version", strconv.Itoa(s.Props.Metadata.OldestVersion)}, 3, tcell.ColorYellow)
+	s.MetadataTable.RenderRow([]string{"Max Versions", strconv.Itoa(s.Props.Metadata.MaxVersions)}, 4, tcell.ColorYellow)
+	s.MetadataTable.RenderRow([]string{"CAS Required", strconv.FormatBool(s.Props.Metadata.CasRequired)}, 5, tcell.ColorYellow)
+	s.MetadataTable.RenderRow([]string{"Delete Version After", deleteAfter}, 6, tcell.ColorYellow)
+
+	s.CustomMetadataTable.SetTitle("Custom Metadata")
+	i := 0
+	for k, v := range s.Props.Metadata.CustomMetadata {
+		value, ok := v.(string)
+		if !ok {
+			continue
+		}
+		s.CustomMetadataTable.RenderRow([]string{k, value}, i, tcell.ColorYellow)
+		i++
+	}
+
+	s.renderVersionHistory()
+	return nil
+}
+
+func (s *SecretObjTable) renderVersionHistory() {
+	if s.Props.Metadata == nil || len(s.Props.Metadata.Versions) == 0 {
+		return
+	}
+
+	s.VersionHistoryTable.SetTitle("Version History")
+	s.VersionHistoryTable.RenderHeader(SecretObjTableHeaderVersions)
+
+	type vEntry struct {
+		num int
+		v   models.Version
+	}
+	entries := make([]vEntry, 0, len(s.Props.Metadata.Versions))
+	for numStr, v := range s.Props.Metadata.Versions {
+		n, _ := strconv.Atoi(numStr)
+		entries = append(entries, vEntry{n, v})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].num > entries[j].num })
+
+	for i, e := range entries {
+		status := "active"
+		color := tcell.ColorWhite
+		if e.num == s.Props.Metadata.CurrentVersion {
+			status = "current"
+			color = tcell.ColorGreen
+		} else if e.v.Destroyed {
+			status = "destroyed"
+			color = tcell.ColorRed
+		} else if e.v.DeletionTime != "" {
+			status = "deleted"
+			color = tcell.ColorOrange
+		}
+		s.VersionHistoryTable.RenderRow([]string{
+			fmt.Sprintf("v%d", e.num),
+			status,
+			ConvertTimeFormat(e.v.CreatedTime),
+		}, i+1, color)
+	}
+}
+
+func (s *SecretObjTable) renderRows() {
 	keys := make([]string, 0, len(s.Props.Data.Data["data"].(map[string]interface{})))
 	for key := range s.Props.Data.Data["data"].(map[string]interface{}) {
 		keys = append(keys, key)
@@ -239,9 +344,7 @@ func (s *SecretObjTable) renderRows() {
 		}
 		var strValue string
 		if value != nil {
-			strValue = value.(string)
-		} else {
-			strValue = ""
+			strValue = fmt.Sprintf("%v", value)
 		}
 
 		row := []string{
@@ -272,8 +375,30 @@ func (s *SecretObjTable) renderEditArea() {
 	if err != nil {
 		s.Logger.Err(err).Msgf("error: %s", err)
 	}
-	s.TextArea.SetTitle(fmt.Sprintf("%s %s", SecretObjTableTitle, s.Props.SelectedPath))
-	s.TextArea.SetText(string(jsonData), true)
+	s.SetEditStatus("")
+	s.TextArea.SetText(string(jsonData), false)
+
+	s.TextArea.SetChangedFunc(func() {
+		var d map[string]interface{}
+		if jsonErr := json.Unmarshal([]byte(s.TextArea.GetText()), &d); jsonErr != nil {
+			s.TextArea.SetBorderColor(tcell.ColorRed)
+		} else {
+			s.TextArea.SetBorderColor(tcell.ColorGreen)
+			s.SetEditStatus("")
+		}
+	})
+}
+
+// SetEditStatus updates the TextArea title and border to reflect a validation
+// message. An empty msg resets both to their default state.
+func (s *SecretObjTable) SetEditStatus(msg string) {
+	if msg != "" {
+		s.TextArea.SetBorderColor(tcell.ColorRed)
+		s.TextArea.SetTitle(msg)
+	} else {
+		s.TextArea.SetBorderColor(styles.TcellColorStandard)
+		s.TextArea.SetTitle(fmt.Sprintf("%s %s", SecretObjTableTitle, s.Props.SelectedPath))
+	}
 }
 
 func (s *SecretObjTable) SaveData(text string) string {
@@ -284,12 +409,11 @@ func (s *SecretObjTable) SaveData(text string) string {
 
 	err := json.Unmarshal([]byte(text), &data)
 	if err != nil {
-		s.Logger.Err(err).Msgf("Failed to validate json:: %s", err)
+		s.Logger.Err(err).Msgf("Failed to validate json: %s", err)
 		s.Props.UpdatedData = nil
-		return "Failed to validate json:"
-	} else {
-		s.Props.UpdatedData = data
+		return fmt.Sprintf("Invalid JSON: %s", err.Error())
 	}
+	s.Props.UpdatedData = data
 	return ""
 }
 
@@ -355,14 +479,9 @@ func (s *SecretObjTable) validationLogic() {
 }
 
 func ConvertTimeFormat(input string) string {
-	// Parse the input string into a time.Time value
 	t, err := time.Parse(time.RFC3339Nano, input)
 	if err != nil {
 		return input
 	}
-
-	// Format the time.Time value into a human-friendly string
-	output := t.Format("Monday, 02-Jan-06 15:04:05 MST")
-
-	return output
+	return t.Format("Monday, 02-Jan-06 15:04:05 MST")
 }

--- a/tui/component/secret_obj_table_test.go
+++ b/tui/component/secret_obj_table_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
 	"github.com/gdamore/tcell/v2"
 	"github.com/hashicorp/vault/api"
 	"github.com/rivo/tview"

--- a/tui/component/secrets_table.go
+++ b/tui/component/secrets_table.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )

--- a/tui/component/secrets_table_test.go
+++ b/tui/component/secrets_table_test.go
@@ -3,10 +3,10 @@ package component_test
 import (
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"

--- a/tui/component/selections.go
+++ b/tui/component/selections.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/rivo/tview"
 
-	"github.com/dkyanakiev/vaulty/internal/state"
-	"github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/internal/state"
+	"github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 )
 
 var (

--- a/tui/component/selector.go
+++ b/tui/component/selector.go
@@ -1,7 +1,7 @@
 package component
 
 import (
-	"github.com/dkyanakiev/vaulty/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )

--- a/tui/component/text_input.go
+++ b/tui/component/text_input.go
@@ -1,7 +1,7 @@
 package component
 
 import (
-	"github.com/dkyanakiev/vaulty/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/rivo/tview"
 )
 

--- a/tui/component/toggles.go
+++ b/tui/component/toggles.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	primitive "github.com/dkyanakiev/vaulty/tui/primitives"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog"
 )

--- a/tui/component/vaultinfo.go
+++ b/tui/component/vaultinfo.go
@@ -1,7 +1,7 @@
 package component
 
 import (
-	"github.com/dkyanakiev/vaulty/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/rivo/tview"
 )
 

--- a/tui/component/vaultinfo_test.go
+++ b/tui/component/vaultinfo_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"
 )

--- a/tui/layout/layout_test.go
+++ b/tui/layout/layout_test.go
@@ -3,7 +3,7 @@ package layout_test
 import (
 	"testing"
 
-	"github.com/dkyanakiev/vaulty/tui/layout"
+	"github.com/dkyanakiev/vaul7y/tui/layout"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"
 )

--- a/tui/primitives/dropdown.go
+++ b/tui/primitives/dropdown.go
@@ -3,7 +3,7 @@ package primitives
 import (
 	"github.com/rivo/tview"
 
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 )
 
 type DropDown struct {

--- a/tui/primitives/input.go
+++ b/tui/primitives/input.go
@@ -23,6 +23,10 @@ func NewInputField(label, placeholder string) *InputField {
 	return &InputField{i}
 }
 
+func (i *InputField) SetLabel(label string) {
+	i.primitive.SetLabel(label)
+}
+
 func (i *InputField) SetDoneFunc(handler func(k tcell.Key)) {
 	i.primitive.SetDoneFunc(handler)
 }

--- a/tui/primitives/table.go
+++ b/tui/primitives/table.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 )
 
 // Table is a wrapper of a tview.Table primitive.

--- a/tui/primitives/text.go
+++ b/tui/primitives/text.go
@@ -1,7 +1,7 @@
 package primitives
 
 import (
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )

--- a/tui/primitives/textarea.go
+++ b/tui/primitives/textarea.go
@@ -1,7 +1,8 @@
 package primitives
 
 import (
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/atotto/clipboard"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -18,6 +19,16 @@ func NewTextArea() *TextArea {
 	t.Box.SetBorderColor(styles.TcellColorStandard)
 	t.Box.SetBorder(true)
 
+	// Wire Ctrl+Q (copy) and Ctrl+V (paste) to the system clipboard so that
+	// paste inserts the whole string at once instead of character by character.
+	t.SetClipboard(
+		func(text string) { clipboard.WriteAll(text) },
+		func() string {
+			text, _ := clipboard.ReadAll()
+			return text
+		},
+	)
+
 	return &TextArea{
 		primitive: t,
 	}
@@ -28,7 +39,11 @@ func (t *TextArea) Primitive() tview.Primitive {
 }
 
 func (t *TextArea) SetText(text string, cursorAtEnd bool) *tview.TextArea {
-	return t.primitive.SetText(text, true)
+	return t.primitive.SetText(text, cursorAtEnd)
+}
+
+func (t *TextArea) SetChangedFunc(handler func()) *tview.TextArea {
+	return t.primitive.SetChangedFunc(handler)
 }
 
 func (t *TextArea) SetBorder(wrap bool) {

--- a/tui/view/auth.go
+++ b/tui/view/auth.go
@@ -1,0 +1,43 @@
+package view
+
+import (
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func (v *View) AuthMethods() {
+	v.viewSwitch()
+	v.Layout.Body.Clear()
+	v.Layout.Body.SetTitle("Auth Methods")
+	v.Layout.Container.SetFocus(v.components.AuthTable.Table.Primitive())
+	v.Layout.Container.SetInputCapture(v.InputAuthMethods)
+	v.components.Commands.Update(component.AuthCommands)
+
+	update := func() {
+		v.state.RLock()
+		data := v.state.AuthMethods
+		v.state.RUnlock()
+
+		v.components.AuthTable.Props.Data = data
+		v.components.AuthTable.Render()
+		v.Draw()
+		v.components.AuthTable.Table.ScrollToTop()
+	}
+
+	v.Watcher.SubscribeToAuthMethods(func() { v.Layout.Container.QueueUpdateDraw(update) })
+	update()
+
+	v.state.Elements.TableMain = v.components.AuthTable.Table.Primitive().(*tview.Table)
+}
+
+func (v *View) inputAuthMethods(event *tcell.EventKey) *tcell.EventKey {
+	if event == nil {
+		return event
+	}
+	switch event.Key() {
+	case tcell.KeyEsc:
+		v.Mounts()
+	}
+	return event
+}

--- a/tui/view/init.go
+++ b/tui/view/init.go
@@ -2,10 +2,11 @@ package view
 
 import (
 	"fmt"
+	"strings"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/styles"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 )
 
@@ -13,14 +14,12 @@ func (v *View) Init(version string) {
 	// ClusterInfo
 	v.state.Version = version
 	v.components.VaultInfo.Props.Info = fmt.Sprintf(
-		"%sAddress: %s%s %s\n%sVersion:%s %s\n",
-		styles.HighlightSecondaryTag,
-		styles.StandardColorTag,
-		v.state.VaultAddress,
-		styles.StandardColorTag,
-		styles.HighlightSecondaryTag,
-		styles.StandardColorTag,
-		v.state.VaultVersion,
+		"%sAddress:%s %s | %sStatus:%s -\n%sVersion:%s %s | %sToken TTL:%s - | %sPolicies:%s -\n",
+		styles.HighlightSecondaryTag, styles.StandardColorTag, v.state.VaultAddress,
+		styles.HighlightSecondaryTag, styles.StandardColorTag,
+		styles.HighlightSecondaryTag, styles.StandardColorTag, v.state.VaultVersion,
+		styles.HighlightSecondaryTag, styles.StandardColorTag,
+		styles.HighlightSecondaryTag, styles.StandardColorTag,
 	)
 
 	v.components.VaultInfo.Bind(v.Layout.Elements.ClusterInfo)
@@ -61,6 +60,10 @@ func (v *View) Init(version string) {
 	v.components.NamespaceTable.Bind(v.Layout.Body)
 	v.components.NamespaceTable.Props.HandleNoResources = v.handleNoResources
 
+	// AuthTable
+	v.components.AuthTable.Bind(v.Layout.Body)
+	v.components.AuthTable.Props.HandleNoResources = v.handleNoResources
+
 	// Selections
 	//v.components.Selections.Bind(v.Layout.Elements.Dropdowns)
 	// v.components.Selections.Render()
@@ -98,7 +101,9 @@ func (v *View) Init(version string) {
 	// SearchField
 	v.components.Search.Bind(v.Layout.Footer)
 	v.components.Search.Props.DoneFunc = func(key tcell.Key) {
+		v.state.Lock()
 		v.state.Toggle.Search = false
+		v.state.Unlock()
 		v.components.Search.InputField.SetText("")
 		v.Layout.MainPage.ResizeItem(v.Layout.Footer, 0, 0)
 		v.Layout.Footer.RemoveItem(v.components.Search.InputField.Primitive())
@@ -110,7 +115,7 @@ func (v *View) Init(version string) {
 		v.FilterText = text
 	}
 
-	// TextInput (New secret)
+	// TextInput (New secret / Jump to path)
 	v.components.TextInfoInput.Bind(v.Layout.Footer)
 	v.components.TextInfoInput.Props.DoneFunc = func(key tcell.Key) {
 		v.Layout.MainPage.ResizeItem(v.Layout.Footer, 0, 0)
@@ -118,11 +123,26 @@ func (v *View) Init(version string) {
 		v.Layout.Container.SetFocus(v.state.Elements.TableMain)
 		v.components.TextInfoInput.Render()
 
-		newText := v.components.TextInfoInput.InputField.GetText()
-		v.state.NewSecretName = newText
-		v.CreateNewSecretObject(newText)
+		inputText := v.components.TextInfoInput.InputField.GetText()
 		v.components.TextInfoInput.InputField.SetText("")
+
+		v.state.Lock()
+		jumpToPath := v.state.Toggle.JumpToPath
 		v.state.Toggle.TextInput = false
+		v.state.Toggle.JumpToPath = false
+		v.state.Unlock()
+
+		if jumpToPath {
+			v.state.Lock()
+			v.state.SelectedPath = inputText
+			v.state.Unlock()
+			v.Secrets(inputText, "false")
+		} else {
+			v.state.Lock()
+			v.state.NewSecretName = inputText
+			v.state.Unlock()
+			v.promptSecretFormat(inputText)
+		}
 	}
 
 	// Error
@@ -136,6 +156,13 @@ func (v *View) Init(version string) {
 		v.Layout.Pages.RemovePage(component.PageNameError)
 		v.Layout.Container.SetFocus(v.state.Elements.TableMain)
 		///v.GoBack()
+	}
+
+	// Confirm
+	v.components.Confirm.Bind(v.Layout.Pages)
+	v.components.Confirm.Props.Done = func(buttonIndex int, buttonLabel string) {
+		v.Layout.Pages.RemovePage(component.PageNameConfirm)
+		v.Layout.Container.SetFocus(v.components.SecretObjTable.TextArea.Primitive())
 	}
 
 	// Info
@@ -158,30 +185,75 @@ func (v *View) Init(version string) {
 	v.Watcher.SubscribeHandler(models.HandleError, v.handleError)
 	v.Watcher.SubscribeHandler(models.HandleFatal, v.handleFatal)
 
-	stop := make(chan struct{})
+	go v.DrawLoop(v.drawStop)
 
-	go v.DrawLoop(stop)
-	// v.logger.Debug().Msgf("Active page is: %s", v.state.Elements.TableMain.GetTitle())
-	// Set initial view to jobs
+	// Fetch token info and seal status once at startup for the header.
+	go func() {
+		ttl, policies, err := v.Client.TokenInfo()
+		if err != nil {
+			v.logger.Warn().Err(err).Msg("failed to fetch token info")
+		} else {
+			v.state.Lock()
+			v.state.TokenTTL = ttl
+			v.state.TokenPolicies = policies
+			v.state.Unlock()
+		}
+
+		sealStatus, clusterName, err := v.Client.SealStatus()
+		if err != nil {
+			v.logger.Warn().Err(err).Msg("failed to fetch seal status")
+		} else {
+			v.state.Lock()
+			v.state.SealStatus = sealStatus
+			v.state.ClusterName = clusterName
+			v.state.Unlock()
+		}
+
+		v.Layout.Container.QueueUpdateDraw(v.UpdateVaultInfo)
+	}()
+
 	v.Mounts()
 }
 
 func (v *View) UpdateVaultInfo() {
-	// Update the component's state
-	// newNS := fmt.Sprintf("%s/%s", v.state.RootNamespace, v.state.SelectedNamespace)
+	v.state.RLock()
+	addr := v.state.VaultAddress
+	ver := v.state.VaultVersion
+	ttl := v.state.TokenTTL
+	policies := v.state.TokenPolicies
+	sealStatus := v.state.SealStatus
+	clusterName := v.state.ClusterName
+	v.state.RUnlock()
+
+	ttlStr := fmt.Sprintf("%ds", ttl)
+	if ttl == 0 {
+		ttlStr = "∞"
+	}
+
+	policyStr := strings.Join(policies, ", ")
+	if policyStr == "" {
+		policyStr = "-"
+	}
+
+	clusterStr := ""
+	if clusterName != "" {
+		clusterStr = fmt.Sprintf(" | %sCluster:%s %s", styles.HighlightSecondaryTag, styles.StandardColorTag, clusterName)
+	}
+
+	statusStr := sealStatus
+	if statusStr == "" {
+		statusStr = "-"
+	}
 
 	v.components.VaultInfo.Props.Info = fmt.Sprintf(
-		"%sAddress: %s%s %s\n%sVersion:%s %s\n",
-		styles.HighlightSecondaryTag,
-		styles.StandardColorTag,
-		v.state.VaultAddress,
-		styles.StandardColorTag,
-		styles.HighlightSecondaryTag,
-		styles.StandardColorTag,
-		v.state.VaultVersion,
+		"%sAddress:%s %s | %sStatus:%s %s%s\n%sVersion:%s %s | %sToken TTL:%s %s | %sPolicies:%s %s\n",
+		styles.HighlightSecondaryTag, styles.StandardColorTag, addr,
+		styles.HighlightSecondaryTag, styles.StandardColorTag, statusStr, clusterStr,
+		styles.HighlightSecondaryTag, styles.StandardColorTag, ver,
+		styles.HighlightSecondaryTag, styles.StandardColorTag, ttlStr,
+		styles.HighlightSecondaryTag, styles.StandardColorTag, policyStr,
 	)
 
-	// Re-render the component
 	v.components.VaultInfo.Render()
 }
 

--- a/tui/view/inputs.go
+++ b/tui/view/inputs.go
@@ -33,6 +33,11 @@ func (v *View) InputSecret(event *tcell.EventKey) *tcell.EventKey {
 	return v.inputSecret(event)
 }
 
+func (v *View) InputAuthMethods(event *tcell.EventKey) *tcell.EventKey {
+	event = v.InputMainCommands(event)
+	return v.inputAuthMethods(event)
+}
+
 func (v *View) InputMainCommands(event *tcell.EventKey) *tcell.EventKey {
 	if event == nil {
 		return event
@@ -45,20 +50,10 @@ func (v *View) InputMainCommands(event *tcell.EventKey) *tcell.EventKey {
 		v.Mounts()
 	case tcell.KeyCtrlP:
 		v.VPolicy()
-		// Needs editing
-		// case tcell.KeyCtrlJ:
-		// 	v.SecretObject()
 	case tcell.KeyCtrlT:
 		v.Namespaces()
-	case tcell.KeyRune:
-		r := event.Rune()
-
-		if (r == 's') && !v.components.SecretObjTable.Editable {
-			if !v.Layout.Footer.HasFocus() {
-				v.Layout.Container.SetFocus(v.state.Elements.DropDownNamespace)
-			}
-		}
-
+	case tcell.KeyCtrlA:
+		v.AuthMethods()
 	}
 
 	return event

--- a/tui/view/mounts.go
+++ b/tui/view/mounts.go
@@ -1,8 +1,8 @@
 package view
 
 import (
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -22,15 +22,21 @@ func (v *View) Mounts() {
 	v.state.SelectedObject = ""
 
 	update := func() {
-		v.components.MountsTable.Props.Data = v.state.Mounts
+		v.state.RLock()
+		mounts := v.state.Mounts
+		selectedMount := v.state.SelectedMount
+		selectedPath := v.state.SelectedPath
+		v.state.RUnlock()
+
+		v.components.MountsTable.Props.Data = mounts
 		v.components.MountsTable.Render()
 		v.Draw()
 		v.logger.Debug().Msg("Updated mounts table")
-		v.logger.Debug().Msgf("Selected mount is: %v", v.state.SelectedMount)
-		v.logger.Debug().Msgf("Selected path is: %v", v.state.SelectedPath)
+		v.logger.Debug().Msgf("Selected mount is: %v", selectedMount)
+		v.logger.Debug().Msgf("Selected path is: %v", selectedPath)
 	}
 
-	v.Watcher.SubscribeToMounts(update)
+	v.Watcher.SubscribeToMounts(func() { v.Layout.Container.QueueUpdateDraw(update) })
 	// v.Watcher.UpdateMounts()
 	update()
 
@@ -52,7 +58,9 @@ func (v *View) inputMounts(event *tcell.EventKey) *tcell.EventKey {
 	switch event.Key() {
 	case tcell.KeyEnter:
 		if v.components.MountsTable.Table.Primitive().HasFocus() {
+			v.state.Lock()
 			v.state.SelectedMount = v.components.MountsTable.GetIDForSelection()
+			v.state.Unlock()
 			v.Secrets("", "false")
 			return nil
 		}
@@ -60,7 +68,9 @@ func (v *View) inputMounts(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Rune() {
 		case 'e':
 			if v.components.MountsTable.Table.Primitive().HasFocus() {
+				v.state.Lock()
 				v.state.SelectedMount = v.components.MountsTable.GetIDForSelection()
+				v.state.Unlock()
 				v.Secrets("", "false")
 				return nil
 			}

--- a/tui/view/namespace.go
+++ b/tui/view/namespace.go
@@ -3,7 +3,7 @@ package view
 import (
 	"fmt"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -20,9 +20,12 @@ func (v *View) Namespaces() {
 	v.Layout.Container.SetInputCapture(v.InputNamespaces)
 
 	update := func() {
-		// v.components.NamespaceTable.Props.Data = v.filterNamespaces(v.state.Namespaces)
-		v.logger.Debug().Msgf("Current ns list: %v", v.state.Namespaces)
-		v.components.NamespaceTable.Props.Data = v.state.Namespaces
+		v.state.RLock()
+		namespaces := v.state.Namespaces
+		v.state.RUnlock()
+
+		v.logger.Debug().Msgf("Current ns list: %v", namespaces)
+		v.components.NamespaceTable.Props.Data = namespaces
 		v.components.NamespaceTable.Render()
 		v.Draw()
 		v.components.NamespaceTable.Table.ScrollToTop()
@@ -33,7 +36,7 @@ func (v *View) Namespaces() {
 		update()
 	}
 
-	v.Watcher.SubscribeToNamespaces(update)
+	v.Watcher.SubscribeToNamespaces(func() { v.Layout.Container.QueueUpdateDraw(update) })
 
 	update()
 
@@ -54,35 +57,42 @@ func (v *View) inputNamespaces(event *tcell.EventKey) *tcell.EventKey {
 	case tcell.KeyEsc:
 		//v.GoBack()
 	case tcell.KeyCtrlD:
-		v.logger.Debug().Msgf("Going back to default namespace: %v", v.state.DefaultNamespace)
-		v.state.SelectedNamespace = v.state.DefaultNamespace
-		v.components.TogglesInfo.Props.Namespace = v.state.DefaultNamespace
+		v.state.RLock()
+		defaultNs := v.state.DefaultNamespace
+		v.state.RUnlock()
+		v.logger.Debug().Msgf("Going back to default namespace: %v", defaultNs)
+		v.state.Lock()
+		v.state.SelectedNamespace = defaultNs
+		v.state.Unlock()
+		v.components.TogglesInfo.Props.Namespace = defaultNs
 		v.components.TogglesInfo.Render()
-		v.state.SelectedNamespace = v.state.DefaultNamespace
-		//v.Client.ChangeNamespace(v.state.DefaultNamespace)
-		v.Watcher.Unsubscribe()
 		v.Mounts()
 		return nil
 	case tcell.KeyCtrlW:
-		v.logger.Debug().Msgf("Going back to root namespace : %v", v.state.RootNamespace)
-		v.state.SelectedNamespace = v.state.RootNamespace
-		v.components.TogglesInfo.Props.Namespace = v.state.RootNamespace
+		v.state.RLock()
+		rootNs := v.state.RootNamespace
+		v.state.RUnlock()
+		v.logger.Debug().Msgf("Going back to root namespace : %v", rootNs)
+		v.state.Lock()
+		v.state.SelectedNamespace = rootNs
+		v.state.Unlock()
+		v.components.TogglesInfo.Props.Namespace = rootNs
 		v.components.TogglesInfo.Render()
-		v.state.SelectedNamespace = v.state.RootNamespace
-		// v.Client.ChangeNamespace(v.state.RootNamespace)
-		v.Watcher.Unsubscribe()
 		v.Mounts()
 		return nil
 	case tcell.KeyEnter:
 		selectdNs := v.components.NamespaceTable.GetIDForSelection()
+		v.state.RLock()
+		currentNs := v.state.SelectedNamespace
+		v.state.RUnlock()
 		v.logger.Debug().Msgf("Selected namespace is: %v", selectdNs)
-		newNs := fmt.Sprintf("%s/%s", v.state.SelectedNamespace, selectdNs)
+		newNs := fmt.Sprintf("%s/%s", currentNs, selectdNs)
 		v.logger.Debug().Msgf("Changing namespace to: %s", newNs)
+		v.state.Lock()
+		v.state.SelectedNamespace = newNs
+		v.state.Unlock()
 		v.components.TogglesInfo.Props.Namespace = newNs
 		v.components.TogglesInfo.Render()
-		v.state.SelectedNamespace = newNs
-		// v.Client.ChangeNamespace(newNs)
-		v.Watcher.Unsubscribe()
 		v.Mounts()
 		return nil
 	}

--- a/tui/view/newsecret.go
+++ b/tui/view/newsecret.go
@@ -1,0 +1,211 @@
+package view
+
+import (
+	"fmt"
+
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const (
+	pageFormatSel = "formatsel"
+	pageKVForm    = "kvform"
+)
+
+// showFormatSelector shows a "JSON / Key-Value / Cancel" modal.
+// restoreCapture is reinstated when the modal is dismissed so the caller's
+// view input handler resumes correctly regardless of which button is chosen.
+func (v *View) showFormatSelector(
+	title, msg string,
+	jsonFn, kvFn func(),
+	restoreCapture func(*tcell.EventKey) *tcell.EventKey,
+) {
+	modal := primitive.NewModal(title, []string{"JSON", "Key-Value", "Cancel"}, tcell.ColorDarkOliveGreen)
+	modal.SetText(msg)
+	modal.SetDoneFunc(func(_ int, label string) {
+		v.Layout.Pages.RemovePage(pageFormatSel)
+		v.Layout.Container.SetInputCapture(restoreCapture)
+		switch label {
+		case "JSON":
+			jsonFn()
+		case "Key-Value":
+			kvFn()
+		default:
+			v.Layout.Container.SetFocus(v.state.Elements.TableMain)
+		}
+	})
+
+	// Neutral capture while the modal is open — prevents the underlying view's
+	// shortcuts ('P', 'U', 'b', '/', etc.) from firing through the modal.
+	v.Layout.Container.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		return event
+	})
+
+	v.Layout.Pages.AddPage(pageFormatSel, modal.Container(), true, true)
+	v.Layout.Container.SetFocus(modal.Primitive())
+}
+
+// promptSecretFormat is called after the user types a new secret name (ctrl-n flow).
+func (v *View) promptSecretFormat(name string) {
+	basePath := v.components.SecretsTable.Props.SelectedPath
+	fullPath := fmt.Sprintf("%s%s", basePath, name)
+	mount := v.state.SelectedMount
+
+	v.showFormatSelector(
+		"New Secret",
+		fmt.Sprintf("Choose format for: %s", fullPath),
+		func() { v.openNewSecretJSONEditor(mount, fullPath) },
+		func() {
+			v.showKVForm(mount, fullPath, nil, false,
+				func() {
+					v.state.Lock()
+					v.state.SelectedPath = fullPath
+					v.state.Unlock()
+					v.SecretObject(mount, fullPath)
+				},
+				v.InputSecrets,
+			)
+		},
+		v.InputSecrets,
+	)
+}
+
+// openNewSecretJSONEditor creates an empty secret and opens the JSON editor.
+func (v *View) openNewSecretJSONEditor(mount, path string) {
+	go func() {
+		if err := v.Client.CreateNewSecret(mount, path); err != nil {
+			v.Layout.Container.QueueUpdateDraw(func() { v.handleError(err.Error()) })
+			return
+		}
+		v.Layout.Container.QueueUpdateDraw(func() {
+			v.state.Lock()
+			v.state.SelectedPath = path
+			v.state.Unlock()
+			v.SecretObject(mount, path)
+			v.components.Commands.Update(component.SecretsObjectPatchCommands)
+			v.components.SecretObjTable.SetEditable(true)
+			v.components.TogglesInfo.Props.Editable = true
+			v.components.SecretObjTable.Props.Update = "UPDATE"
+			v.components.TogglesInfo.Render()
+			v.components.SecretObjTable.ToggleView()
+			v.components.SecretObjTable.TextView.ScrollToBeginning()
+			v.Layout.Container.SetFocus(v.components.SecretObjTable.TextArea.Primitive())
+		})
+	}()
+}
+
+// showKVForm displays a centered form for entering one or more key-value pairs.
+//
+//   - initialData pre-populates the form; nil or empty starts with one blank pair.
+//   - patch selects PATCH vs full-write semantics when calling the API.
+//   - onSuccess is called on the event goroutine after the write succeeds.
+//   - restoreCapture is reinstated when the form is dismissed (cancel or save).
+func (v *View) showKVForm(
+	mount, path string,
+	initialData map[string]interface{},
+	patch bool,
+	onSuccess func(),
+	restoreCapture func(*tcell.EventKey) *tcell.EventKey,
+) {
+	type kvPair struct {
+		key   *tview.InputField
+		value *tview.InputField
+	}
+
+	var (
+		pairs []*kvPair
+		form  *tview.Form
+	)
+
+	addPair := func(k, val string) {
+		idx := len(pairs) + 1
+		p := &kvPair{
+			key: tview.NewInputField().
+				SetLabel(fmt.Sprintf("Key %d:   ", idx)).
+				SetFieldWidth(28).
+				SetText(k),
+			value: tview.NewInputField().
+				SetLabel(fmt.Sprintf("Value %d: ", idx)).
+				SetFieldWidth(28).
+				SetText(val),
+		}
+		pairs = append(pairs, p)
+		if form != nil {
+			form.AddFormItem(p.key)
+			form.AddFormItem(p.value)
+		}
+	}
+
+	dismiss := func() {
+		v.Layout.Pages.RemovePage(pageKVForm)
+		v.Layout.Container.SetInputCapture(restoreCapture)
+		v.Layout.Container.SetFocus(v.state.Elements.TableMain)
+	}
+
+	saveForm := func() {
+		data := make(map[string]interface{})
+		for _, p := range pairs {
+			k := p.key.GetText()
+			if k != "" {
+				data[k] = p.value.GetText()
+			}
+		}
+		if len(data) == 0 {
+			return
+		}
+		v.Layout.Pages.RemovePage(pageKVForm)
+		v.Layout.Container.SetInputCapture(restoreCapture)
+		go func() {
+			if err := v.Client.UpdateSecretObjectKV2(mount, path, patch, data); err != nil {
+				v.Layout.Container.QueueUpdateDraw(func() { v.handleError(err.Error()) })
+				return
+			}
+			v.Layout.Container.QueueUpdateDraw(onSuccess)
+		}()
+	}
+
+	form = tview.NewForm()
+
+	if len(initialData) > 0 {
+		for k, val := range initialData {
+			addPair(k, fmt.Sprintf("%v", val))
+		}
+	} else {
+		addPair("", "")
+	}
+
+	form.AddButton("Add Key", func() {
+		addPair("", "")
+		v.Draw()
+	})
+	form.AddButton("Save", saveForm)
+	form.AddButton("Cancel", dismiss)
+
+	form.SetTitle(" Key-Value Secret ").SetBorder(true)
+	form.SetBorderColor(tcell.ColorDarkOliveGreen)
+	form.SetButtonsAlign(tview.AlignCenter)
+
+	centered := tview.NewFlex().
+		AddItem(nil, 0, 1, false).
+		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(nil, 0, 1, false).
+			AddItem(form, 0, 2, true).
+			AddItem(nil, 0, 1, false), 65, 0, true).
+		AddItem(nil, 0, 1, false)
+
+	v.Layout.Container.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event == nil {
+			return nil
+		}
+		if event.Key() == tcell.KeyEsc {
+			dismiss()
+			return nil
+		}
+		return event
+	})
+
+	v.Layout.Pages.AddPage(pageKVForm, centered, true, true)
+	v.Layout.Container.SetFocus(form)
+}

--- a/tui/view/policy.go
+++ b/tui/view/policy.go
@@ -2,8 +2,9 @@ package view
 
 import (
 	"regexp"
+	"time"
 
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -19,21 +20,44 @@ func (v *View) VPolicy() {
 	//table := v.components.in
 
 	update := func() {
-		if v.state.Toggle.Search {
-			v.state.Filter.Policy = v.FilterText
+		v.state.RLock()
+		searching := v.state.Toggle.Search
+		v.state.RUnlock()
+
+		v.mutex.RLock()
+		filterText := v.FilterText
+		v.mutex.RUnlock()
+
+		if searching {
+			v.state.Lock()
+			v.state.Filter.Policy = filterText
+			v.state.Unlock()
 		}
-		v.components.PolicyTable.Props.Data = v.filterPolicies()
+
+		v.state.RLock()
+		data := v.filterPolicies()
+		v.state.RUnlock()
+
+		v.components.PolicyTable.Props.Data = data
 		v.components.PolicyTable.Render()
 		v.Draw()
 		v.components.PolicyTable.Table.ScrollToTop()
 	}
 
+	var debounce *time.Timer
 	search.Props.ChangedFunc = func(text string) {
+		v.mutex.Lock()
 		v.FilterText = text
-		update()
+		v.mutex.Unlock()
+		if debounce != nil {
+			debounce.Stop()
+		}
+		debounce = time.AfterFunc(150*time.Millisecond, func() {
+			v.Layout.Container.QueueUpdateDraw(update)
+		})
 	}
 
-	v.Watcher.SubscribeToPolicies(update)
+	v.Watcher.SubscribeToPolicies(func() { v.Layout.Container.QueueUpdateDraw(update) })
 	update()
 
 	v.state.Elements.TableMain = v.components.PolicyTable.Table.Primitive().(*tview.Table)
@@ -83,11 +107,13 @@ func (v *View) filterPolicies() []string {
 	data := v.state.PolicyList
 	filter := v.state.Filter.Policy
 	if filter != "" {
-		rx, _ := regexp.Compile(filter)
+		rx, err := regexp.Compile(filter)
+		if err != nil {
+			return data
+		}
 		result := []string{}
 		for _, p := range data {
-			switch true {
-			case rx.MatchString(p):
+			if rx.MatchString(p) {
 				result = append(result, p)
 			}
 		}

--- a/tui/view/policyacl.go
+++ b/tui/view/policyacl.go
@@ -1,7 +1,8 @@
 package view
 
 import (
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/atotto/clipboard"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -13,21 +14,30 @@ func (v *View) PolicyACL(policyName string) {
 	v.Layout.Container.SetFocus(v.components.PolicyAclTable.TextView.Primitive())
 	v.components.PolicyAclTable.TextView.Clear().ScrollToBeginning()
 	v.components.Commands.Update(component.PolicyACLCommands)
-	v.Layout.Container.SetInputCapture(v.inputPolicyACL)
+	v.Layout.Container.SetInputCapture(v.InputPolicyACL)
 
 	v.state.SelectedPolicyName = policyName
 	v.components.PolicyAclTable.Props.SelectedPolicyName = policyName
 
 	update := func() {
-		v.components.PolicyAclTable.Props.SelectedPolicyACL = v.state.PolicyACL
+		v.state.RLock()
+		acl := v.state.PolicyACL
+		v.state.RUnlock()
+
+		v.components.PolicyAclTable.Props.SelectedPolicyACL = acl
 		v.components.PolicyAclTable.Render()
 		v.Draw()
 	}
-	v.Watcher.SubscribeToPoliciesACL(update)
+	v.Watcher.SubscribeToPoliciesACL(func() { v.Layout.Container.QueueUpdateDraw(update) })
 	update()
 
 	v.state.Elements.TextMain = v.components.PolicyAclTable.TextView.Primitive().(*tview.TextView)
 
+}
+
+func (v *View) InputPolicyACL(event *tcell.EventKey) *tcell.EventKey {
+	event = v.InputMainCommands(event)
+	return v.inputPolicyACL(event)
 }
 
 func (v *View) inputPolicyACL(event *tcell.EventKey) *tcell.EventKey {
@@ -35,9 +45,82 @@ func (v *View) inputPolicyACL(event *tcell.EventKey) *tcell.EventKey {
 		return event
 	}
 
+	editing := v.components.PolicyAclTable.IsEditable()
+
 	switch event.Key() {
+	case tcell.KeyCtrlW:
+		if editing {
+			v.savePolicyEdit()
+			return nil
+		}
 	case tcell.KeyEsc:
+		if editing {
+			v.components.PolicyAclTable.SetEditable(false)
+			v.components.PolicyAclTable.Render()
+			v.components.Commands.Update(component.PolicyACLCommands)
+			v.Layout.Container.SetFocus(v.components.PolicyAclTable.TextView.Primitive())
+			return nil
+		}
 		v.VPolicy()
+	case tcell.KeyRune:
+		if !editing {
+			switch event.Rune() {
+			case 'E', 'e':
+				v.components.PolicyAclTable.SetEditable(true)
+				v.components.PolicyAclTable.RenderEditArea()
+				v.components.Commands.Update(component.PolicyACLEditCommands)
+				v.Layout.Container.SetFocus(v.components.PolicyAclTable.TextArea.Primitive())
+				return nil
+			case 'c':
+				content := v.components.PolicyAclTable.Props.SelectedPolicyACL
+				clipboard.WriteAll(content) //nolint:errcheck
+				return nil
+			case 'w':
+				v.components.PolicyAclTable.ToggleWrap()
+				v.Draw()
+				return nil
+			case 'j':
+				v.components.PolicyAclTable.ScrollDown(1)
+				v.Draw()
+				return nil
+			case 'k':
+				v.components.PolicyAclTable.ScrollUp(1)
+				v.Draw()
+				return nil
+			case 'd':
+				v.components.PolicyAclTable.ScrollDown(component.ScrollHalfPage)
+				v.Draw()
+				return nil
+			case 'u':
+				v.components.PolicyAclTable.ScrollUp(component.ScrollHalfPage)
+				v.Draw()
+				return nil
+			case 'g':
+				v.components.PolicyAclTable.TextView.ScrollToBeginning()
+				v.Draw()
+				return nil
+			case 'G':
+				v.components.PolicyAclTable.TextView.ScrollToEnd()
+				v.Draw()
+				return nil
+			}
+		}
 	}
 	return event
+}
+
+func (v *View) savePolicyEdit() {
+	name := v.components.PolicyAclTable.Props.SelectedPolicyName
+	rules := v.components.PolicyAclTable.TextArea.GetText()
+
+	if err := v.Client.UpdatePolicy(name, rules); err != nil {
+		v.handleError(err.Error())
+		return
+	}
+
+	v.components.PolicyAclTable.SetEditable(false)
+	v.components.PolicyAclTable.Render()
+	v.components.Commands.Update(component.PolicyACLCommands)
+	v.Layout.Container.SetFocus(v.components.PolicyAclTable.TextView.Primitive())
+	v.handleInfo("Policy updated successfully")
 }

--- a/tui/view/secretobj.go
+++ b/tui/view/secretobj.go
@@ -1,16 +1,24 @@
 package view
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/atotto/clipboard"
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
 func (v *View) SecretObject(mount, path string) {
 	v.viewSwitch()
+	v.components.SecretObjTable.SetEditable(false)
+	v.components.SecretObjTable.ShowMetadata = false
+	v.components.SecretObjTable.ShowJson = false
+	v.components.TogglesInfo.Props.Editable = false
+	v.components.TogglesInfo.Render()
 	v.Layout.Body.SetTitle("Secret object")
 	v.Layout.Container.SetInputCapture(v.InputSecret)
 	v.Layout.Container.SetFocus(v.components.SecretObjTable.Table.Primitive())
@@ -24,17 +32,22 @@ func (v *View) SecretObject(mount, path string) {
 	v.components.SecretObjTable.Props.ObscureSecrets = true
 
 	update := func() {
-		v.logger.Debug().Msgf("Focus set to %s", v.state.Elements.TableMain.GetTitle())
-		v.logger.Debug().Msgf("Selected path is: %v", v.state.SelectedPath)
-		if !v.components.SecretObjTable.Editable {
+		v.state.RLock()
+		secret := v.state.SelectedSecret
+		meta := v.state.SelectedSecretMeta
+		selectedPath := v.state.SelectedPath
+		v.state.RUnlock()
+
+		v.logger.Debug().Msgf("Selected path is: %v", selectedPath)
+		if !v.components.SecretObjTable.IsEditable() {
+			v.components.SecretObjTable.Props.Data = secret
+			v.components.SecretObjTable.Props.Metadata = meta
 			v.components.SecretObjTable.Render()
-			v.components.SecretObjTable.Props.Data = v.state.SelectedSecret
-			v.components.SecretObjTable.Props.Metadata = v.state.SelectedSecretMeta
 			v.Draw()
 		}
 	}
 
-	v.Watcher.SubscribeToSecret(mount, path, update)
+	v.Watcher.SubscribeToSecret(mount, path, func() { v.Layout.Container.QueueUpdateDraw(update) })
 	update()
 
 	v.state.Elements.TableMain = v.components.SecretObjTable.Table.Primitive().(*tview.Table)
@@ -48,7 +61,7 @@ func (v *View) inputSecret(event *tcell.EventKey) *tcell.EventKey {
 
 	switch event.Key() {
 	case tcell.KeyRune:
-		if !v.components.SecretObjTable.Editable {
+		if !v.components.SecretObjTable.IsEditable() {
 			switch event.Rune() {
 			case 'h':
 				v.components.SecretObjTable.Props.ObscureSecrets = !v.components.SecretObjTable.Props.ObscureSecrets
@@ -71,41 +84,44 @@ func (v *View) inputSecret(event *tcell.EventKey) *tcell.EventKey {
 			case 'b':
 				v.goBack()
 			case 't':
+				v.state.RLock()
+				meta := v.state.SelectedSecretMeta
+				v.state.RUnlock()
+				if meta == nil {
+					return nil // v1 engine — no metadata endpoint
+				}
 				v.components.SecretObjTable.ShowMetadata = !v.components.SecretObjTable.ShowMetadata
-				v.logger.Debug().Msgf("Show metadata: %v", v.state.SelectedSecretMeta.UpdatedTime)
+				v.logger.Debug().Msgf("Toggle metadata panel: %v", v.components.SecretObjTable.ShowMetadata)
 				v.components.SecretObjTable.ToggleMetaView()
 			case 'j':
 				v.components.SecretObjTable.ShowJson = !v.components.SecretObjTable.ShowJson
 				v.components.SecretObjTable.ToggleView()
 			case 'P':
-				v.components.Commands.Update(component.SecretsObjectPatchCommands)
-				v.components.SecretObjTable.Editable = true
-				v.components.TogglesInfo.Props.Editable = true
-				v.components.SecretObjTable.Props.Update = "PATCH"
-				v.components.TogglesInfo.Render()
-				v.components.SecretObjTable.ToggleView()
-				v.components.SecretObjTable.TextView.ScrollToBeginning()
-				v.Layout.Container.SetFocus(v.components.SecretObjTable.TextArea.Primitive())
+				v.promptUpdateFormat("PATCH")
 				return nil
 			case 'U':
-				v.components.Commands.Update(component.SecretsObjectPatchCommands)
-				v.components.SecretObjTable.Editable = true
-				v.components.TogglesInfo.Props.Editable = true
-				v.components.SecretObjTable.Props.Update = "UPDATE"
-				v.components.TogglesInfo.Render()
-				v.components.SecretObjTable.ToggleView()
-				v.components.SecretObjTable.TextView.ScrollToBeginning()
-				v.Layout.Container.SetFocus(v.components.SecretObjTable.TextArea.Primitive())
+				v.promptUpdateFormat("UPDATE")
+				return nil
+			case 'D':
+				v.confirmDeleteVersion()
+				return nil
+			case 'R':
+				v.promptRollback()
+				return nil
+			case 'X':
+				v.promptDestroyVersion()
+				return nil
+			case 'M':
+				v.editSecretMetadata()
 				return nil
 			}
 		}
 	case tcell.KeyCtrlW:
-		v.patchSecret()
-		v.goBack()
+		v.confirmSecretUpdate()
 		return nil
 	case tcell.KeyEsc:
-		if v.components.SecretObjTable.Editable {
-			v.components.SecretObjTable.Editable = false
+		if v.components.SecretObjTable.IsEditable() {
+			v.components.SecretObjTable.SetEditable(false)
 			v.components.TogglesInfo.Props.Editable = false
 			v.components.TogglesInfo.Render()
 			v.components.SecretObjTable.ToggleView()
@@ -120,41 +136,299 @@ func (v *View) inputSecret(event *tcell.EventKey) *tcell.EventKey {
 }
 
 func (v *View) goBack() {
-	v.state.SelectedPath = strings.TrimSuffix(v.state.SelectedPath, "/") // Remove trailing slash
+	v.state.Lock()
+	v.state.SelectedPath = strings.TrimSuffix(v.state.SelectedPath, "/")
 	lastSlashIndex := strings.LastIndex(v.state.SelectedPath, "/")
 	if lastSlashIndex != -1 {
-		v.state.SelectedPath = v.state.SelectedPath[:lastSlashIndex+1] // Keep the slash
+		v.state.SelectedPath = v.state.SelectedPath[:lastSlashIndex+1]
 	} else if v.state.SelectedPath != "" {
-		v.state.SelectedPath = "" // If no slash left and it's not empty, set to empty
+		v.state.SelectedPath = ""
 		v.components.SecretsTable.Props.SelectedPath = ""
 	}
-	v.Secrets(v.state.SelectedPath, "false")
+	path := v.state.SelectedPath
+	v.state.Unlock()
+	v.Secrets(path, "false")
 }
 
-func (v *View) patchSecret() {
-	var patch bool
-	if v.components.SecretObjTable.Props.Update == "PATCH" {
-		v.logger.Debug().Msg("PATCH secret")
-		patch = true
-	} else {
-		v.logger.Debug().Msg("UPDATE secret")
-		patch = false
-	}
-	ok := v.components.SecretObjTable.SaveData(v.components.SecretObjTable.TextArea.GetText())
-	if ok != "" {
-		v.handleError(ok)
-	} else {
-		if v.state.Enterprise {
-			v.logger.Debug().Msgf("Enterprise version detected, setting namespace to %v", v.state.SelectedNamespace)
-			v.Client.ChangeNamespace(v.state.SelectedNamespace)
-		}
-		v.logger.Debug().Msgf("Updated secret object is: %v", v.components.SecretObjTable.Props.UpdatedData)
-		err := v.Client.UpdateSecretObjectKV2(v.state.SelectedMount, v.components.SecretObjTable.Props.SelectedPath, patch, v.components.SecretObjTable.Props.UpdatedData)
+// patchSecret validates, saves, and submits the edited JSON. Returns true on
+// success so the caller knows whether to navigate away.
+func (v *View) patchSecret() bool {
+	patch := v.components.SecretObjTable.Props.Update == "PATCH"
+	v.logger.Debug().Msgf("patchSecret: patch=%v", patch)
 
-		if err != nil {
-			v.handleError(string(err.Error()))
-		}
-		v.components.SecretObjTable.Editable = false
-		v.components.SecretObjTable.ToggleView()
+	errMsg := v.components.SecretObjTable.SaveData(v.components.SecretObjTable.TextArea.GetText())
+	if errMsg != "" {
+		// Show the error inline in the TextArea title so the user stays in
+		// edit mode and can correct the JSON without losing their work.
+		v.components.SecretObjTable.SetEditStatus(errMsg)
+		v.Draw()
+		return false
 	}
+
+	v.state.RLock()
+	enterprise := v.state.Enterprise
+	ns := v.state.SelectedNamespace
+	mount := v.state.SelectedMount
+	v.state.RUnlock()
+
+	if enterprise {
+		v.logger.Debug().Msgf("Enterprise version detected, setting namespace to %v", ns)
+		v.Client.ChangeNamespace(ns)
+	}
+	v.logger.Debug().Msgf("Updated secret object is: %v", v.components.SecretObjTable.Props.UpdatedData)
+	err := v.Client.UpdateSecretObjectKV2(mount, v.components.SecretObjTable.Props.SelectedPath, patch, v.components.SecretObjTable.Props.UpdatedData)
+	if err != nil {
+		v.handleError(err.Error())
+		return false
+	}
+
+	v.components.SecretObjTable.SetEditable(false)
+	v.components.SecretObjTable.ToggleView()
+	return true
+}
+
+func (v *View) confirmDeleteVersion() {
+	mount := v.state.SelectedMount
+	path := v.components.SecretObjTable.Props.SelectedPath
+	msg := fmt.Sprintf("Delete current version of:\n%s\n\nContinue?", path)
+
+	v.components.Confirm.Props.Done = func(_ int, label string) {
+		v.Layout.Pages.RemovePage(component.PageNameConfirm)
+		if label == "Yes" {
+			go func() {
+				if err := v.Client.DeleteCurrentSecretVersion(mount, path); err != nil {
+					v.Layout.Container.QueueUpdateDraw(func() { v.handleError(err.Error()) })
+				} else {
+					v.Layout.Container.QueueUpdateDraw(v.goBack)
+				}
+			}()
+		} else {
+			v.Layout.Container.SetFocus(v.components.SecretObjTable.Table.Primitive())
+		}
+	}
+	v.components.Confirm.Render(msg) //nolint:errcheck
+	v.Layout.Container.SetFocus(v.components.Confirm.FocusPrimitive())
+}
+
+func (v *View) promptRollback() {
+	origDoneFunc := v.components.TextInfoInput.Props.DoneFunc
+
+	v.state.Lock()
+	v.state.Toggle.TextInput = true
+	v.state.Toggle.JumpToPath = false
+	v.state.Unlock()
+	v.components.TextInfoInput.InputField.SetLabel("Rollback to version: ")
+	v.components.TextInfoInput.InputField.SetText("")
+
+	mount := v.state.SelectedMount
+	path := v.components.SecretObjTable.Props.SelectedPath
+
+	v.components.TextInfoInput.Props.DoneFunc = func(key tcell.Key) {
+		v.components.TextInfoInput.Props.DoneFunc = origDoneFunc
+		text := v.components.TextInfoInput.InputField.GetText()
+		v.Layout.MainPage.ResizeItem(v.Layout.Footer, 0, 0)
+		v.Layout.Footer.RemoveItem(v.components.TextInfoInput.InputField.Primitive())
+		v.state.Lock()
+		v.state.Toggle.TextInput = false
+		v.state.Unlock()
+		v.components.TextInfoInput.InputField.SetLabel("")
+
+		version, err := strconv.Atoi(strings.TrimSpace(text))
+		if err != nil || version < 1 {
+			v.handleError("Invalid version number")
+			return
+		}
+		go func() {
+			if err := v.Client.RollbackSecret(mount, path, version); err != nil {
+				v.Layout.Container.QueueUpdateDraw(func() { v.handleError(err.Error()) })
+			} else {
+				v.Layout.Container.QueueUpdateDraw(func() { v.SecretObject(mount, path) })
+			}
+		}()
+	}
+
+	v.TextInput()
+}
+
+func (v *View) promptDestroyVersion() {
+	origDoneFunc := v.components.TextInfoInput.Props.DoneFunc
+
+	v.state.Lock()
+	v.state.Toggle.TextInput = true
+	v.state.Toggle.JumpToPath = false
+	v.state.Unlock()
+	v.components.TextInfoInput.InputField.SetLabel("Destroy version #: ")
+	v.components.TextInfoInput.InputField.SetText("")
+
+	mount := v.state.SelectedMount
+	path := v.components.SecretObjTable.Props.SelectedPath
+
+	v.components.TextInfoInput.Props.DoneFunc = func(key tcell.Key) {
+		v.components.TextInfoInput.Props.DoneFunc = origDoneFunc
+		text := v.components.TextInfoInput.InputField.GetText()
+		v.Layout.MainPage.ResizeItem(v.Layout.Footer, 0, 0)
+		v.Layout.Footer.RemoveItem(v.components.TextInfoInput.InputField.Primitive())
+		v.state.Lock()
+		v.state.Toggle.TextInput = false
+		v.state.Unlock()
+		v.components.TextInfoInput.InputField.SetLabel("")
+
+		version, err := strconv.Atoi(strings.TrimSpace(text))
+		if err != nil || version < 1 {
+			v.handleError("Invalid version number")
+			return
+		}
+
+		msg := fmt.Sprintf("PERMANENTLY DESTROY version %d of:\n%s\n\nThis CANNOT be undone. Continue?", version, path)
+		v.components.Confirm.Props.Done = func(_ int, label string) {
+			v.Layout.Pages.RemovePage(component.PageNameConfirm)
+			if label == "Yes" {
+				go func() {
+					if err := v.Client.DestroySecretVersions(mount, path, []int{version}); err != nil {
+						v.Layout.Container.QueueUpdateDraw(func() { v.handleError(err.Error()) })
+					} else {
+						v.Layout.Container.QueueUpdateDraw(func() { v.SecretObject(mount, path) })
+					}
+				}()
+			} else {
+				v.Layout.Container.SetFocus(v.components.SecretObjTable.Table.Primitive())
+			}
+		}
+		v.components.Confirm.Render(msg) //nolint:errcheck
+		v.Layout.Container.SetFocus(v.components.Confirm.FocusPrimitive())
+	}
+
+	v.TextInput()
+}
+
+func (v *View) editSecretMetadata() {
+	v.state.RLock()
+	meta := v.state.SelectedSecretMeta
+	v.state.RUnlock()
+	if meta == nil {
+		v.handleError("Metadata editing is only supported for KV v2")
+		return
+	}
+
+	mount := v.state.SelectedMount
+	path := v.components.SecretObjTable.Props.SelectedPath
+
+	initial := map[string]interface{}{
+		"max_versions":         meta.MaxVersions,
+		"cas_required":         meta.CasRequired,
+		"delete_version_after": meta.DeleteVersionAfter,
+	}
+	jsonBytes, _ := json.MarshalIndent(initial, "", "  ")
+
+	v.components.Commands.Update(component.SecretsObjectPatchCommands)
+	v.components.SecretObjTable.SetEditable(true)
+	v.components.TogglesInfo.Props.Editable = true
+	v.components.SecretObjTable.Props.Update = "METADATA"
+	v.components.TogglesInfo.Render()
+	v.components.SecretObjTable.ToggleView()
+	v.components.SecretObjTable.TextArea.SetText(string(jsonBytes), true)
+	v.components.SecretObjTable.TextView.ScrollToBeginning()
+	v.Layout.Container.SetFocus(v.components.SecretObjTable.TextArea.Primitive())
+
+	origDone := v.components.Confirm.Props.Done
+	v.components.Confirm.Props.Done = func(btnIdx int, label string) {
+		v.Layout.Pages.RemovePage(component.PageNameConfirm)
+		if label == "Yes" {
+			raw := v.components.SecretObjTable.TextArea.GetText()
+			var opts map[string]interface{}
+			if err := json.Unmarshal([]byte(raw), &opts); err != nil {
+				v.components.SecretObjTable.SetEditStatus("Invalid JSON: " + err.Error())
+				v.Draw()
+				v.Layout.Container.SetFocus(v.components.SecretObjTable.TextArea.Primitive())
+				return
+			}
+			optsToSend := opts
+			go func() {
+				opts := optsToSend
+				if err := v.Client.UpdateSecretMetadata(mount, path, opts); err != nil {
+					v.Layout.Container.QueueUpdateDraw(func() {
+						v.handleError(err.Error())
+						v.components.SecretObjTable.SetEditable(false)
+						v.components.TogglesInfo.Props.Editable = false
+						v.components.TogglesInfo.Render()
+						v.components.SecretObjTable.ToggleView()
+					})
+				} else {
+					v.Layout.Container.QueueUpdateDraw(func() {
+						v.components.SecretObjTable.SetEditable(false)
+						v.components.TogglesInfo.Props.Editable = false
+						v.components.TogglesInfo.Render()
+						v.SecretObject(mount, path)
+					})
+				}
+			}()
+		} else {
+			v.components.SecretObjTable.SetEditable(false)
+			v.components.TogglesInfo.Props.Editable = false
+			v.components.TogglesInfo.Render()
+			v.components.SecretObjTable.ToggleView()
+			v.Layout.Container.SetFocus(v.components.SecretObjTable.Table.Primitive())
+		}
+		v.components.Confirm.Props.Done = origDone
+	}
+}
+
+// promptUpdateFormat shows the JSON/Key-Value format selector for P/U operations.
+func (v *View) promptUpdateFormat(mode string) {
+	mount := v.state.SelectedMount
+	path := v.components.SecretObjTable.Props.SelectedPath
+	patch := mode == "PATCH"
+
+	openJSONEditor := func() {
+		v.components.Commands.Update(component.SecretsObjectPatchCommands)
+		v.components.SecretObjTable.SetEditable(true)
+		v.components.TogglesInfo.Props.Editable = true
+		v.components.SecretObjTable.Props.Update = mode
+		v.components.TogglesInfo.Render()
+		v.components.SecretObjTable.ToggleView()
+		v.components.SecretObjTable.TextView.ScrollToBeginning()
+		v.Layout.Container.SetFocus(v.components.SecretObjTable.TextArea.Primitive())
+	}
+
+	openKVForm := func() {
+		var initialData map[string]interface{}
+		if d := v.components.SecretObjTable.Props.Data; d != nil && d.Data != nil {
+			if kv, ok := d.Data["data"].(map[string]interface{}); ok {
+				initialData = kv
+			}
+		}
+		v.showKVForm(mount, path, initialData, patch,
+			func() { v.SecretObject(mount, path) },
+			v.InputSecret,
+		)
+	}
+
+	v.showFormatSelector(
+		fmt.Sprintf("%s Secret", mode),
+		fmt.Sprintf("Choose format for %s:", path),
+		openJSONEditor,
+		openKVForm,
+		v.InputSecret,
+	)
+}
+
+func (v *View) confirmSecretUpdate() {
+	op := v.components.SecretObjTable.Props.Update
+	path := v.components.SecretObjTable.Props.SelectedPath
+	msg := fmt.Sprintf("%s secret at path:\n%s\n\nContinue?", op, path)
+
+	v.components.Confirm.Props.Done = func(_ int, label string) {
+		v.Layout.Pages.RemovePage(component.PageNameConfirm)
+		if label == "Yes" {
+			if v.patchSecret() {
+				v.goBack()
+			} else {
+				v.Layout.Container.SetFocus(v.components.SecretObjTable.TextArea.Primitive())
+			}
+		} else {
+			v.Layout.Container.SetFocus(v.components.SecretObjTable.TextArea.Primitive())
+		}
+	}
+	v.components.Confirm.Render(msg) //nolint:errcheck
+	v.Layout.Container.SetFocus(v.components.Confirm.FocusPrimitive())
 }

--- a/tui/view/secrets.go
+++ b/tui/view/secrets.go
@@ -5,9 +5,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/tui/component"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -35,25 +36,48 @@ func (v *View) Secrets(path string, secretBool string) {
 	}
 
 	update := func() {
-		if v.state.Toggle.Search {
-			v.state.Filter.Object = v.FilterText
-			v.components.TogglesInfo.Props.FilterText = v.FilterText
-		}
-		v.components.SecretsTable.Props.Data = v.filterSecrets()
-		v.components.SecretsTable.Props.SelectedMount = v.state.SelectedMount
+		v.state.RLock()
+		searching := v.state.Toggle.Search
+		selectedMount := v.state.SelectedMount
+		v.state.RUnlock()
 
+		v.mutex.RLock()
+		filterText := v.FilterText
+		v.mutex.RUnlock()
+
+		if searching {
+			v.state.Lock()
+			v.state.Filter.Object = filterText
+			v.state.Unlock()
+			v.components.TogglesInfo.Props.FilterText = filterText
+		}
+
+		v.state.RLock()
+		data := v.filterSecrets()
+		v.state.RUnlock()
+
+		v.components.SecretsTable.Props.Data = data
+		v.components.SecretsTable.Props.SelectedMount = selectedMount
 		v.components.SecretsTable.Render()
 		v.Draw()
 		v.components.SecretsTable.Table.ScrollToTop()
 	}
 
+	var debounce *time.Timer
 	search.Props.ChangedFunc = func(text string) {
+		v.mutex.Lock()
 		v.FilterText = text
-		update()
+		v.mutex.Unlock()
+		if debounce != nil {
+			debounce.Stop()
+		}
+		debounce = time.AfterFunc(150*time.Millisecond, func() {
+			v.Layout.Container.QueueUpdateDraw(update)
+		})
 	}
 
 	v.Watcher.SubscribeToSecrets(v.components.SecretsTable.Props.SelectedMount,
-		v.components.SecretsTable.Props.SelectedPath, update)
+		v.components.SecretsTable.Props.SelectedPath, func() { v.Layout.Container.QueueUpdateDraw(update) })
 	update()
 
 	v.state.Elements.TableMain = v.components.SecretsTable.Table.Primitive().(*tview.Table)
@@ -93,8 +117,13 @@ func (v *View) inputSecrets(event *tcell.EventKey) *tcell.EventKey {
 	case tcell.KeyCtrlN:
 		v.logger.Debug().Msgf("Running New Secret view with : %v", v.state.SelectedPath)
 		if !v.Layout.Footer.HasFocus() {
-			if !v.state.Toggle.TextInput {
+			v.state.RLock()
+			textInput := v.state.Toggle.TextInput
+			v.state.RUnlock()
+			if !textInput {
+				v.state.Lock()
 				v.state.Toggle.TextInput = true
+				v.state.Unlock()
 				v.components.TextInfoInput.InputField.SetText("")
 				v.TextInput()
 			} else {
@@ -131,12 +160,37 @@ func (v *View) inputSecrets(event *tcell.EventKey) *tcell.EventKey {
 			}
 		case '/':
 			if !v.Layout.Footer.HasFocus() {
-				if !v.state.Toggle.Search {
+				v.state.RLock()
+				searching := v.state.Toggle.Search
+				v.state.RUnlock()
+				if !searching {
+					v.state.Lock()
 					v.state.Toggle.Search = true
+					v.state.Unlock()
 					v.components.Search.InputField.SetText("")
 					v.Search()
 				} else {
 					v.Layout.Container.SetFocus(v.components.Search.InputField.Primitive())
+				}
+				return nil
+			}
+		case 'J':
+			if !v.Layout.Footer.HasFocus() {
+				v.state.RLock()
+				textInput := v.state.Toggle.TextInput
+				v.state.RUnlock()
+				if !textInput {
+					v.state.Lock()
+					v.state.Toggle.TextInput = true
+					v.state.Toggle.JumpToPath = true
+					v.state.Unlock()
+					v.components.TextInfoInput.InputField.SetText("")
+					v.TextInput()
+				} else {
+					v.state.Lock()
+					v.state.Toggle.JumpToPath = true
+					v.state.Unlock()
+					v.Layout.Container.SetFocus(v.components.TextInfoInput.InputField.Primitive())
 				}
 				return nil
 			}
@@ -150,11 +204,13 @@ func (v *View) filterSecrets() []models.SecretPath {
 	data := v.state.SecretsData
 	filter := v.state.Filter.Object
 	if filter != "" {
-		rx, _ := regexp.Compile(filter)
+		rx, err := regexp.Compile(filter)
+		if err != nil {
+			return data
+		}
 		var result []models.SecretPath
 		for _, p := range data {
-			switch true {
-			case rx.MatchString(p.PathName):
+			if rx.MatchString(p.PathName) {
 				result = append(result, p)
 			}
 		}

--- a/tui/view/view.go
+++ b/tui/view/view.go
@@ -3,12 +3,13 @@ package view
 import (
 	"sync"
 
-	"github.com/dkyanakiev/vaulty/internal/models"
-	"github.com/dkyanakiev/vaulty/internal/state"
-	"github.com/dkyanakiev/vaulty/tui/component"
-	"github.com/dkyanakiev/vaulty/tui/layout"
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/state"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/layout"
 	"github.com/rs/zerolog"
 )
+
 
 const (
 	historySize = 15
@@ -19,6 +20,14 @@ type Client interface {
 	CreateNewSecret(mount string, path string) error
 	ListNamespaces() ([]string, error)
 	ChangeNamespace(ns string) []string
+	DeleteCurrentSecretVersion(mount, path string) error
+	DestroySecretVersions(mount, path string, versions []int) error
+	RollbackSecret(mount, path string, version int) error
+	UpdateSecretMetadata(mount, path string, opts map[string]interface{}) error
+	UpdatePolicy(name, rules string) error
+	ListAuthMethods() (map[string]*models.AuthMethod, error)
+	TokenInfo() (ttl int64, policies []string, err error)
+	SealStatus() (status string, clusterName string, err error)
 }
 
 type Watcher interface {
@@ -31,6 +40,7 @@ type Watcher interface {
 	SubscribeToNamespaces(notify func())
 	SubscribeToSecrets(selectedMount, selectedPath string, notify func())
 	SubscribeToSecret(selectedMount, selectedPath string, notify func())
+	SubscribeToAuthMethods(notify func())
 	UpdateMounts()
 }
 
@@ -43,11 +53,12 @@ type View struct {
 	state      *state.State
 	logger     *zerolog.Logger
 	components *Components
-	mutex      sync.Mutex
+	mutex      sync.RWMutex
 
 	FilterText string ""
 
-	draw chan struct{}
+	draw     chan struct{}
+	drawStop chan struct{}
 }
 
 type Components struct {
@@ -57,12 +68,14 @@ type Components struct {
 	SecretsTable   *component.SecretsTable
 	SecretObjTable *component.SecretObjTable
 	NamespaceTable *component.NamespaceTable
+	AuthTable      *component.AuthTable
 	Commands       *component.Commands
 	VaultInfo      *component.VaultInfo
 	Search         *component.SearchField
 	Error          *component.Error
 	Info           *component.Info
 	Failure        *component.Info
+	Confirm        *component.Confirm
 	TogglesInfo    *component.TogglesInfo
 	Selections     *component.Selections
 	JumpToPolicy   *component.JumpToPolicy
@@ -81,6 +94,7 @@ func New(components *Components, watcher Watcher, client Client, state *state.St
 		state:      state,
 		Layout:     layout.New(layout.Default, layout.EnableMouse),
 		draw:       make(chan struct{}, 1),
+		drawStop:   make(chan struct{}),
 		logger:     logger,
 		components: components,
 		history: &History{
@@ -91,7 +105,10 @@ func New(components *Components, watcher Watcher, client Client, state *state.St
 }
 
 func (v *View) Draw() {
-	v.draw <- struct{}{}
+	select {
+	case v.draw <- struct{}{}:
+	default:
+	}
 }
 
 // DrawLoop refreshes the screen when it receives a
@@ -108,6 +125,10 @@ func (v *View) DrawLoop(stop chan struct{}) {
 		}
 
 	}
+}
+
+func (v *View) Shutdown() {
+	close(v.drawStop)
 }
 
 func (v *View) GoBack() {
@@ -132,7 +153,9 @@ func (v *View) addToHistory(ns string, topic string, update func()) {
 }
 
 func (v *View) viewSwitch() {
+	v.Watcher.Unsubscribe()
 	v.resetSearch()
+	v.resetTextInput()
 }
 
 func (v *View) Search() {


### PR DESCRIPTION
---
  Features

  Secret version management (KV v2)
  - D — soft-delete the current version of a secret
  - R — rollback to a previous version (prompted by version number)
  - X — permanently destroy a specific version (with confirmation)
  - M — edit secret metadata inline (max_versions, cas_required, delete_version_after)

  Format selector for create and update
  - Pressing ctrl-n (new secret), P (patch), or U (update) now shows a format picker: JSON opens the existing textarea editor; Key-Value opens a form with labeled field pairs
  - Key-Value form supports multiple key-value pairs via an Add Key button and pre-populates with existing secret data on update

  Auth Methods view (ctrl-a)
  - New screen listing all enabled auth methods with their mount path, type, and description

  Header info bar
  - At startup, fetches and displays Vault address, version, seal status, cluster name, token TTL, and attached policies in the top bar

  Policy ACL editing
  - E — enter edit mode for the selected policy; ctrl-w saves; esc cancels

  Policy ACL navigation (vim-style)
  - j / k — scroll one line down/up
  - d / u — scroll half-page down/up
  - g / G — jump to top/bottom
  - w — toggle word wrap
  - c — copy policy to clipboard

  Confirmation dialogs
  - Destructive operations (delete, destroy, update, rollback) now prompt for confirmation before executing

  ---
  Bug Fixes

  Blank secret view after rollback
  - After using R to rollback, returning to the secret object view showed blank content because ShowMetadata, ShowJson, and Editable state flags were never reset on re-entry. All three are now explicitly reset at the top of SecretObject().

  Pressing t (metadata) on KV v1 panicked
  - t tried to read .UpdatedTime on a nil metadata pointer when the mount is KV v1. Now skips the toggle if metadata is nil.

  Draw() could deadlock
  - Draw() did a blocking send on a buffered channel. If called while the buffer was full it would deadlock. Changed to a non-blocking select/default send.

  Log file not flushed on panic
  - defer logFile.Close() is skipped when the process panics. Replaced with a recover wrapper that closes the file before re-panicking.

  Config error messages written to stdout
  - All startup error messages in configs.go used fmt.Printf/fmt.Println, making them invisible in TUI contexts and impossible to redirect. Changed to fmt.Fprintf(os.Stderr, ...).

  Secret watcher not dispatched on the UI goroutine
  - SubscribeToSecret callback was called directly from the watcher goroutine. Wrapped in QueueUpdateDraw so all UI mutations happen on the tview event loop.

  viewSwitch() did not cancel pending text input
  - Navigating away while a text input prompt was open left the input visible. viewSwitch() now calls resetTextInput() on every view transition, and Watcher.Unsubscribe() is called to stop the previous subscription.

  ---
  Infrastructure / Config

  goreleaser v2 upgrade
  - Updated version: 1 → version: 2
  - Renamed snapshot.name_template → snapshot.version_template
  - Renamed brews.folder → brews.directory (field was renamed in v2 schema)

  ---
  Tests

  internal/vault/kv_test.go
  - Added TestGet_Error — verifies that a KV2 client error is propagated and the returned secret is nil
  - Added TestGetMetadata_Error — same for metadata fetch

  internal/config/configs_test.go (new file)
  - YAML parsing: all non-auth fields loaded correctly from a config file
  - Default refresh rate of 30s applied when omitted
  - Env vars override YAML for VAULT_ADDR, VAULT_TOKEN, VAULT_NAMESPACE, TLS fields
  - VAULTY_REFRESH_RATE parsed as int from env; invalid value falls back to default 30
  - VAULTY_LOG_FILE and VAULTY_LOG_LEVEL loaded from env
  - Priority: env vars always win over YAML

  tui/component/policy_acl_table_test.go
  - ScrollDown increases row offset correctly
  - ScrollDown from offset zero works
  - ScrollUp decreases row offset correctly
  - ScrollUp clamps to 0 when delta exceeds current offset
  - ScrollUp from zero stays at zero
  - ScrollUp with delta exactly equal to offset lands precisely on zero

  ---
  Docs

  docs/usage.md — replaced sparse bullet list with full keyboard reference tables for all views (secret engines, secret object, ACL policies, auth methods, namespaces, header bar)

  CHANGELOG.md — added [0.2.0] - 2026-05-11 section

  README.md — marked version select and rollback as complete in the TODO list

  .github/ISSUE_TEMPLATE/issue_report.md — added terminal dimensions, KV engine version, auth method, namespace, and structured debug log section

  .github/ISSUE_TEMPLATE/feature_request.md — added "Which area does this relate to?" field
  
  Fixes: 
  https://github.com/dkyanakiev/vaul7y/issues/27
  https://github.com/dkyanakiev/vaul7y/issues/23
  https://github.com/dkyanakiev/vaul7y/issues/22