### PR TITLE
feat: configurable theme

### DIFF
--- a/cmd/vaul7y/main.go
+++ b/cmd/vaul7y/main.go
@@ -12,8 +12,8 @@ import (
 	"github.com/dkyanakiev/vaul7y/internal/vault"
 	"github.com/dkyanakiev/vaul7y/internal/watcher"
 	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/dkyanakiev/vaul7y/tui/view"
-	"github.com/gdamore/tcell/v2"
 	"github.com/jessevdk/go-flags"
 	"github.com/rivo/tview"
 )
@@ -49,7 +49,8 @@ func main() {
 		}
 		_ = logFile.Close()
 	}()
-	tview.Styles.PrimitiveBackgroundColor = tcell.NewRGBColor(40, 44, 48)
+	styles.ApplyTheme(cfg.Theme)
+	tview.Styles.PrimitiveBackgroundColor = styles.GetBackgroundColor()
 
 	vaultClient, err := vault.New(func(v *vault.Vault) error {
 		return vault.Default(v, logger, cfg)

--- a/docs/examples/vaul7y.yaml
+++ b/docs/examples/vaul7y.yaml
@@ -12,3 +12,14 @@ vaulty_log_level: debug
 # How often to pull information from Vault. Added in case rate limit is a problem
 # Default is 30 seconds
 # vaulty_refresh_rate: 30
+# optional theme overrides
+# theme:
+#   background: "#282c30"
+#   highlight_primary: "#26ffe6"
+#   highlight_secondary: "#baff26"
+#   standard: "#00b57c"
+#   active: "#b3f1ff"
+#   white: "#ffffff"
+#   light_grey: "#cccccc"
+#   modal_info: "#61877f"
+#   attention: "#d98b6a"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,6 +67,8 @@ Example: [`~/myuser/.vaul7y.yaml`](./examples/vaul7y.yaml)
 Or alternatively pass a config file as an argument using `-c <path/file.yaml>`  
 Example: `vaul7y -c ./new-env.yml`
 
+The config file also supports optional `theme` settings.
+
 #### Authentication and variables priority
 Variables will be loaded in the following order, with the next superseding the previous ones:
 

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -14,15 +14,28 @@ import (
 )
 
 type Config struct {
-	VaultAddr         string `yaml:"vault_addr"`
-	VaultNamespace    string `yaml:"vault_namespace"`
-	VaultToken        string `yaml:"vault_token"`
-	VaultCaCert       string `yaml:"vault_cacert"`
-	VaultClientCert   string `yaml:"vault_client_cert"`
-	VaultClientKey    string `yaml:"vault_client_key"`
-	VaultyLogFile     string `yaml:"vaulty_log_file"`
-	VaultyLogLevel    string `yaml:"vaulty_log_level"`
-	VaultyRefreshRate int    `yaml:"vaulty_refresh_rate"`
+	VaultAddr         string      `yaml:"vault_addr"`
+	VaultNamespace    string      `yaml:"vault_namespace"`
+	VaultToken        string      `yaml:"vault_token"`
+	VaultCaCert       string      `yaml:"vault_cacert"`
+	VaultClientCert   string      `yaml:"vault_client_cert"`
+	VaultClientKey    string      `yaml:"vault_client_key"`
+	VaultyLogFile     string      `yaml:"vaulty_log_file"`
+	VaultyLogLevel    string      `yaml:"vaulty_log_level"`
+	VaultyRefreshRate int         `yaml:"vaulty_refresh_rate"`
+	Theme             ThemeConfig `yaml:"theme"`
+}
+
+type ThemeConfig struct {
+	Background         string `yaml:"background"`
+	HighlightPrimary   string `yaml:"highlight_primary"`
+	HighlightSecondary string `yaml:"highlight_secondary"`
+	Standard           string `yaml:"standard"`
+	Active             string `yaml:"active"`
+	White              string `yaml:"white"`
+	LightGrey          string `yaml:"light_grey"`
+	ModalInfo          string `yaml:"modal_info"`
+	Attention          string `yaml:"attention"`
 }
 
 func LoadConfig(cfgFile string) Config {

--- a/internal/config/configs_test.go
+++ b/internal/config/configs_test.go
@@ -29,6 +29,8 @@ func TestLoadConfig_YAML(t *testing.T) {
 	t.Run("non-auth fields parsed from yaml", func(t *testing.T) {
 		// Use env var for VAULT_TOKEN so the ~/.vault-token file on disk
 		// (if present) cannot override what we assert on for other fields.
+		t.Setenv("VAULT_ADDR", "")
+		t.Setenv("VAULT_NAMESPACE", "")
 		t.Setenv("VAULT_TOKEN", "env-token")
 
 		cfg := config.LoadConfig(writeConfig(t, `
@@ -38,12 +40,31 @@ vault_namespace: yaml-ns
 vaulty_log_file: /tmp/vaul7y.log
 vaulty_log_level: info
 vaulty_refresh_rate: 45
+theme:
+  background: "#202428"
+  highlight_primary: "#111111"
+  highlight_secondary: "#222222"
+  standard: "#333333"
+  active: "#444444"
+  white: "#555555"
+  light_grey: "#666666"
+  modal_info: "#777777"
+  attention: "#888888"
 `))
 		assert.Equal(t, "https://yaml.vault.example.com", cfg.VaultAddr)
 		assert.Equal(t, "yaml-ns", cfg.VaultNamespace)
 		assert.Equal(t, "/tmp/vaul7y.log", cfg.VaultyLogFile)
 		assert.Equal(t, "info", cfg.VaultyLogLevel)
 		assert.Equal(t, 45, cfg.VaultyRefreshRate)
+		assert.Equal(t, "#202428", cfg.Theme.Background)
+		assert.Equal(t, "#111111", cfg.Theme.HighlightPrimary)
+		assert.Equal(t, "#222222", cfg.Theme.HighlightSecondary)
+		assert.Equal(t, "#333333", cfg.Theme.Standard)
+		assert.Equal(t, "#444444", cfg.Theme.Active)
+		assert.Equal(t, "#555555", cfg.Theme.White)
+		assert.Equal(t, "#666666", cfg.Theme.LightGrey)
+		assert.Equal(t, "#777777", cfg.Theme.ModalInfo)
+		assert.Equal(t, "#888888", cfg.Theme.Attention)
 		// Token was overridden by env, so we only check it came from env.
 		assert.Equal(t, "env-token", cfg.VaultToken)
 	})

--- a/tui/component/auth_table.go
+++ b/tui/component/auth_table.go
@@ -6,7 +6,6 @@ import (
 	"github.com/dkyanakiev/vaul7y/internal/models"
 	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/dkyanakiev/vaul7y/tui/styles"
-	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
@@ -72,6 +71,6 @@ func (a *AuthTable) renderRows() {
 	for i, k := range keys {
 		m := a.Props.Data[k]
 		row := []string{k, m.Type, m.Description}
-		a.Table.RenderRow(row, i+1, tcell.ColorWhite)
+		a.Table.RenderRow(row, i+1, styles.NeutralColor())
 	}
 }

--- a/tui/component/logo.go
+++ b/tui/component/logo.go
@@ -5,18 +5,19 @@ import (
 	"strings"
 
 	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/rivo/tview"
 )
 
 var LogoASCII = []string{
-	`[#00b57c]                           `,
+	`                           `,
 	`____   ____            .___________        `,
 	`\   \ /   /____   __ __|  \______  \___.__.`,
 	` \   Y   /\__  \ |  |  \  |   /    <   |  |`,
 	`  \     /  / __ \|  |  /  |__/    / \___  |`,
 	`   \___/  (____  /____/|____/____/  / ____|`,
 	`			    \/                   \/     `,
-	`[#26ffe6]Vaul7y - Terminal Dashboard`,
+	`Vaul7y - Terminal Dashboard`,
 }
 
 type Logo struct {
@@ -44,9 +45,9 @@ func (l *Logo) Render() error {
 		return ErrComponentNotBound
 	}
 
-	versionText := fmt.Sprintf("[#26ffe6]version: %s", l.Props.Version)
+	versionText := fmt.Sprintf("%sversion: %s", styles.HighlightPrimaryTag, l.Props.Version)
 	logo := strings.Join(LogoASCII, "\n")
-	logo = fmt.Sprintf("%s\n%s", logo, versionText)
+	logo = fmt.Sprintf("%s%s\n%s", styles.StandardColorTag, logo, versionText)
 	l.TextView.SetText(logo)
 	l.slot.AddItem(l.TextView.Primitive(), 0, 1, false)
 	return nil

--- a/tui/component/logo_test.go
+++ b/tui/component/logo_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dkyanakiev/vaul7y/tui/component"
 	"github.com/dkyanakiev/vaul7y/tui/component/componentfakes"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"
 )
@@ -25,9 +26,9 @@ func TestLogo_Pass(t *testing.T) {
 	r.NoError(err)
 
 	text := textView.SetTextArgsForCall(0)
-	versionText := fmt.Sprintf("[#26ffe6]version: %s", "0.0.0")
+	versionText := fmt.Sprintf("%sversion: %s", styles.HighlightPrimaryTag, "0.0.0")
 	expectedLogo := strings.Join(component.LogoASCII, "\n")
-	expectedLogo = fmt.Sprintf("%s\n%s", expectedLogo, versionText)
+	expectedLogo = fmt.Sprintf("%s%s\n%s", styles.StandardColorTag, expectedLogo, versionText)
 	r.Equal(text, expectedLogo)
 }
 

--- a/tui/component/mounts_table.go
+++ b/tui/component/mounts_table.go
@@ -140,19 +140,19 @@ func (m *MountsTable) renderRows() {
 }
 
 func (m *MountsTable) cellColor(mountType string) tcell.Color {
-	c := tcell.ColorWhite
+	c := styles.NeutralColor()
 	// Setup splits based on type
 	switch mountType {
 	case models.MountTypeSystem:
 		c = styles.TcellColorAttention
 	case models.MountTypeCubbyhole:
-		c = tcell.ColorYellow
+		c = styles.MountCubbyholeColor()
 	case models.MountTypeIdentity:
-		c = tcell.ColorRed
+		c = styles.MountIdentityColor()
 	case models.MountTypeKV:
-		c = tcell.ColorGreenYellow
+		c = styles.MountKVColor()
 	case models.MountTypePki:
-		c = tcell.ColorBlue
+		c = styles.MountPkiColor()
 	}
 
 	return c

--- a/tui/component/namespace_table.go
+++ b/tui/component/namespace_table.go
@@ -1,13 +1,11 @@
 package component
 
 import (
-	"github.com/gdamore/tcell/v2"
-	"github.com/rivo/tview"
-	"github.com/rs/zerolog"
-
 	"github.com/dkyanakiev/vaul7y/internal/models"
 	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/dkyanakiev/vaul7y/tui/styles"
+	"github.com/rivo/tview"
+	"github.com/rs/zerolog"
 )
 
 const TableTitleNamespaces = "Namespaces"
@@ -91,7 +89,7 @@ func (n *NamespaceTable) renderRows() {
 		}
 
 		index = i + 1
-		n.Table.RenderRow(row, index, tcell.ColorWhite)
+		n.Table.RenderRow(row, index, styles.NeutralColor())
 	}
 }
 

--- a/tui/component/policy_table.go
+++ b/tui/component/policy_table.go
@@ -4,7 +4,6 @@ import (
 	"github.com/dkyanakiev/vaul7y/internal/models"
 	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/dkyanakiev/vaul7y/tui/styles"
-	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
@@ -96,7 +95,7 @@ func (p *PolicyTable) renderRows() {
 			policy,
 		}
 		index := i + 1
-		c := tcell.ColorYellow
+		c := styles.RowColor()
 
 		p.Table.RenderRow(row, index, c)
 	}

--- a/tui/component/secret_obj_table.go
+++ b/tui/component/secret_obj_table.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dkyanakiev/vaul7y/internal/models"
 	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/dkyanakiev/vaul7y/tui/styles"
-	"github.com/gdamore/tcell/v2"
 	"github.com/hashicorp/vault/api"
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog"
@@ -266,13 +265,13 @@ func (s *SecretObjTable) renderMetadata() error {
 	}
 
 	s.MetadataTable.SetTitle("Secret Metadata")
-	s.MetadataTable.RenderRow([]string{"Updated Time", ConvertTimeFormat(s.Props.Metadata.UpdatedTime)}, 0, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Created Time", ConvertTimeFormat(s.Props.Metadata.CreatedTime)}, 1, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Current Version", strconv.Itoa(s.Props.Metadata.CurrentVersion)}, 2, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Oldest Version", strconv.Itoa(s.Props.Metadata.OldestVersion)}, 3, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Max Versions", strconv.Itoa(s.Props.Metadata.MaxVersions)}, 4, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"CAS Required", strconv.FormatBool(s.Props.Metadata.CasRequired)}, 5, tcell.ColorYellow)
-	s.MetadataTable.RenderRow([]string{"Delete Version After", deleteAfter}, 6, tcell.ColorYellow)
+	s.MetadataTable.RenderRow([]string{"Updated Time", ConvertTimeFormat(s.Props.Metadata.UpdatedTime)}, 0, styles.RowColor())
+	s.MetadataTable.RenderRow([]string{"Created Time", ConvertTimeFormat(s.Props.Metadata.CreatedTime)}, 1, styles.RowColor())
+	s.MetadataTable.RenderRow([]string{"Current Version", strconv.Itoa(s.Props.Metadata.CurrentVersion)}, 2, styles.RowColor())
+	s.MetadataTable.RenderRow([]string{"Oldest Version", strconv.Itoa(s.Props.Metadata.OldestVersion)}, 3, styles.RowColor())
+	s.MetadataTable.RenderRow([]string{"Max Versions", strconv.Itoa(s.Props.Metadata.MaxVersions)}, 4, styles.RowColor())
+	s.MetadataTable.RenderRow([]string{"CAS Required", strconv.FormatBool(s.Props.Metadata.CasRequired)}, 5, styles.RowColor())
+	s.MetadataTable.RenderRow([]string{"Delete Version After", deleteAfter}, 6, styles.RowColor())
 
 	s.CustomMetadataTable.SetTitle("Custom Metadata")
 	i := 0
@@ -281,7 +280,7 @@ func (s *SecretObjTable) renderMetadata() error {
 		if !ok {
 			continue
 		}
-		s.CustomMetadataTable.RenderRow([]string{k, value}, i, tcell.ColorYellow)
+		s.CustomMetadataTable.RenderRow([]string{k, value}, i, styles.RowColor())
 		i++
 	}
 
@@ -310,16 +309,16 @@ func (s *SecretObjTable) renderVersionHistory() {
 
 	for i, e := range entries {
 		status := "active"
-		color := tcell.ColorWhite
+		color := styles.NeutralColor()
 		if e.num == s.Props.Metadata.CurrentVersion {
 			status = "current"
-			color = tcell.ColorGreen
+			color = styles.SuccessColor()
 		} else if e.v.Destroyed {
 			status = "destroyed"
-			color = tcell.ColorRed
+			color = styles.ErrorColor()
 		} else if e.v.DeletionTime != "" {
 			status = "deleted"
-			color = tcell.ColorOrange
+			color = styles.WarningColor()
 		}
 		s.VersionHistoryTable.RenderRow([]string{
 			fmt.Sprintf("v%d", e.num),
@@ -352,7 +351,7 @@ func (s *SecretObjTable) renderRows() {
 			strValue,
 		}
 		index := i + 1
-		c := tcell.ColorYellow
+		c := styles.RowColor()
 
 		s.Table.RenderRow(row, index, c)
 	}
@@ -381,9 +380,9 @@ func (s *SecretObjTable) renderEditArea() {
 	s.TextArea.SetChangedFunc(func() {
 		var d map[string]interface{}
 		if jsonErr := json.Unmarshal([]byte(s.TextArea.GetText()), &d); jsonErr != nil {
-			s.TextArea.SetBorderColor(tcell.ColorRed)
+			s.TextArea.SetBorderColor(styles.ErrorColor())
 		} else {
-			s.TextArea.SetBorderColor(tcell.ColorGreen)
+			s.TextArea.SetBorderColor(styles.SuccessColor())
 			s.SetEditStatus("")
 		}
 	})
@@ -393,7 +392,7 @@ func (s *SecretObjTable) renderEditArea() {
 // message. An empty msg resets both to their default state.
 func (s *SecretObjTable) SetEditStatus(msg string) {
 	if msg != "" {
-		s.TextArea.SetBorderColor(tcell.ColorRed)
+		s.TextArea.SetBorderColor(styles.ErrorColor())
 		s.TextArea.SetTitle(msg)
 	} else {
 		s.TextArea.SetBorderColor(styles.TcellColorStandard)

--- a/tui/component/secrets_table.go
+++ b/tui/component/secrets_table.go
@@ -7,7 +7,6 @@ import (
 	"github.com/dkyanakiev/vaul7y/internal/models"
 	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
 	"github.com/dkyanakiev/vaul7y/tui/styles"
-	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
@@ -106,7 +105,7 @@ func (s *SecretsTable) renderRows() {
 			strconv.FormatBool(obj.IsSecret),
 		}
 		index := i + 1
-		c := tcell.ColorYellow
+		c := styles.RowColor()
 
 		s.Table.RenderRow(row, index, c)
 	}

--- a/tui/component/selector.go
+++ b/tui/component/selector.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -51,7 +52,7 @@ func (s *SelectorModal) Render() error {
 	table.Clear()
 
 	for i, v := range s.Props.Items {
-		table.RenderRow([]string{v}, i, tcell.ColorWhite)
+		table.RenderRow([]string{v}, i, styles.NeutralColor())
 	}
 
 	s.Modal.GetTable().SetTitle("Select a Task (alloc: %s)", s.Props.AllocationID)

--- a/tui/primitives/input.go
+++ b/tui/primitives/input.go
@@ -1,6 +1,7 @@
 package primitives
 
 import (
+	"github.com/dkyanakiev/vaul7y/tui/styles"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -16,8 +17,8 @@ func NewInputField(label, placeholder string) *InputField {
 	i.SetAcceptanceFunc(tview.InputFieldMaxLength(40))
 	i.SetPlaceholder(placeholder)
 	i.SetBorder(true)
-	i.SetFieldBackgroundColor(tcell.NewRGBColor(40, 44, 48))
-	i.SetBackgroundColor(tcell.NewRGBColor(40, 44, 48))
+	i.SetFieldBackgroundColor(styles.TcellBackgroundColor)
+	i.SetBackgroundColor(styles.TcellBackgroundColor)
 	i.SetBorderAttributes(tcell.AttrDim)
 
 	return &InputField{i}

--- a/tui/primitives/table.go
+++ b/tui/primitives/table.go
@@ -24,6 +24,9 @@ func NewTable() *Table {
 	t.SetFixed(1, 1)
 	t.SetBorderPadding(0, 0, 1, 1)
 	t.SetBorderColor(styles.TcellColorStandard)
+	if selectedStyle, ok := styles.TableSelectedStyle(); ok {
+		t.SetSelectedStyle(selectedStyle)
+	}
 
 	return &Table{
 		primitive: t,
@@ -83,7 +86,7 @@ func (t *Table) ScrollToTop() *tview.Table {
 }
 
 func (t *Table) SetSelectedStyle(style tcell.Style) {
-	t.tviewTable.SetSelectedStyle(style)
+	t.primitive.SetSelectedStyle(style)
 }
 
 func (t *Table) SetSelectable(rows, columns bool) {

--- a/tui/styles/styles.go
+++ b/tui/styles/styles.go
@@ -2,15 +2,19 @@ package styles
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/dkyanakiev/vaul7y/internal/config"
 	"github.com/gdamore/tcell/v2"
 )
 
 func GetBackgroundColor() tcell.Color {
-	return tcell.NewRGBColor(40, 44, 48)
+	return TcellBackgroundColor
 }
 
 var (
+	themeConfigured = false
+
 	TcellBackgroundColor = tcell.NewRGBColor(40, 44, 48)
 
 	HighlightPrimaryHex   = "#26ffe6"
@@ -33,6 +37,144 @@ var (
 	TcellColorHighlighSecondary = tcell.GetColor(HighlightSecondaryHex)
 	TcellColorStandard          = tcell.GetColor(StandardColorHex)
 	TcellColorActive            = tcell.GetColor(ColorActiveHex)
+	TcellColorWhite             = tcell.GetColor(ColorWhiteHex)
+	TcellColorLightGrey         = tcell.GetColor(ColorLightGreyHex)
 	TcellColorModalInfo         = tcell.GetColor(ColorModalInfoHex)
 	TcellColorAttention         = tcell.GetColor(ColorAttentionHex)
 )
+
+func ApplyTheme(theme config.ThemeConfig) {
+	themeConfigured = hasTheme(theme)
+	if theme.Background != "" {
+		TcellBackgroundColor = tcell.GetColor(normalizeHexColor(theme.Background))
+	}
+	if theme.HighlightPrimary != "" {
+		HighlightPrimaryHex = normalizeHexColor(theme.HighlightPrimary)
+	}
+	if theme.HighlightSecondary != "" {
+		HighlightSecondaryHex = normalizeHexColor(theme.HighlightSecondary)
+	}
+	if theme.Standard != "" {
+		StandardColorHex = normalizeHexColor(theme.Standard)
+	}
+	if theme.Active != "" {
+		ColorActiveHex = normalizeHexColor(theme.Active)
+	}
+	if theme.White != "" {
+		ColorWhiteHex = normalizeHexColor(theme.White)
+	}
+	if theme.LightGrey != "" {
+		ColorLightGreyHex = normalizeHexColor(theme.LightGrey)
+	}
+	if theme.ModalInfo != "" {
+		ColorModalInfoHex = normalizeHexColor(theme.ModalInfo)
+	}
+	if theme.Attention != "" {
+		ColorAttentionHex = normalizeHexColor(theme.Attention)
+	}
+
+	StandardColorTag = fmt.Sprintf("[%s]", StandardColorHex)
+	HighlightPrimaryTag = fmt.Sprintf("[%s]", HighlightPrimaryHex)
+	HighlightSecondaryTag = fmt.Sprintf("[%s]", HighlightSecondaryHex)
+	ColorActiveTag = fmt.Sprintf("[%s]", ColorActiveHex)
+	ColorWhiteTag = fmt.Sprintf("[%s]", ColorWhiteHex)
+	ColorLighGreyTag = fmt.Sprintf("[%s]", ColorLightGreyHex)
+
+	TcellColorHighlighPrimary = tcell.GetColor(HighlightPrimaryHex)
+	TcellColorHighlighSecondary = tcell.GetColor(HighlightSecondaryHex)
+	TcellColorStandard = tcell.GetColor(StandardColorHex)
+	TcellColorActive = tcell.GetColor(ColorActiveHex)
+	TcellColorWhite = tcell.GetColor(ColorWhiteHex)
+	TcellColorLightGrey = tcell.GetColor(ColorLightGreyHex)
+	TcellColorModalInfo = tcell.GetColor(ColorModalInfoHex)
+	TcellColorAttention = tcell.GetColor(ColorAttentionHex)
+}
+
+func TableSelectedStyle() (tcell.Style, bool) {
+	if !themeConfigured {
+		return tcell.StyleDefault, false
+	}
+	return tcell.StyleDefault.Foreground(TcellColorWhite).Background(TcellColorActive), true
+}
+
+func RowColor() tcell.Color {
+	if !themeConfigured {
+		return tcell.ColorYellow
+	}
+	return TcellColorHighlighPrimary
+}
+
+func NeutralColor() tcell.Color {
+	if !themeConfigured {
+		return tcell.ColorWhite
+	}
+	return TcellColorWhite
+}
+
+func SuccessColor() tcell.Color {
+	if !themeConfigured {
+		return tcell.ColorGreen
+	}
+	return TcellColorHighlighSecondary
+}
+
+func WarningColor() tcell.Color {
+	if !themeConfigured {
+		return tcell.ColorOrange
+	}
+	return TcellColorHighlighPrimary
+}
+
+func ErrorColor() tcell.Color {
+	if !themeConfigured {
+		return tcell.ColorRed
+	}
+	return TcellColorAttention
+}
+
+func MountCubbyholeColor() tcell.Color {
+	if !themeConfigured {
+		return tcell.ColorYellow
+	}
+	return TcellColorHighlighPrimary
+}
+
+func MountIdentityColor() tcell.Color {
+	if !themeConfigured {
+		return tcell.ColorRed
+	}
+	return TcellColorAttention
+}
+
+func MountKVColor() tcell.Color {
+	if !themeConfigured {
+		return tcell.ColorGreenYellow
+	}
+	return TcellColorHighlighSecondary
+}
+
+func MountPkiColor() tcell.Color {
+	if !themeConfigured {
+		return tcell.ColorBlue
+	}
+	return TcellColorModalInfo
+}
+
+func hasTheme(theme config.ThemeConfig) bool {
+	return theme.Background != "" ||
+		theme.HighlightPrimary != "" ||
+		theme.HighlightSecondary != "" ||
+		theme.Standard != "" ||
+		theme.Active != "" ||
+		theme.White != "" ||
+		theme.LightGrey != "" ||
+		theme.ModalInfo != "" ||
+		theme.Attention != ""
+}
+
+func normalizeHexColor(color string) string {
+	if strings.HasPrefix(color, "#") {
+		return color
+	}
+	return fmt.Sprintf("#%s", color)
+}

--- a/tui/styles/styles_test.go
+++ b/tui/styles/styles_test.go
@@ -1,0 +1,42 @@
+package styles
+
+import (
+	"testing"
+
+	"github.com/dkyanakiev/vaul7y/internal/config"
+	"github.com/gdamore/tcell/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyTheme(t *testing.T) {
+	ApplyTheme(config.ThemeConfig{
+		Background:         "#202428",
+		HighlightPrimary:   "#111111",
+		HighlightSecondary: "#222222",
+		Standard:           "#333333",
+		Active:             "#444444",
+		White:              "#555555",
+		LightGrey:          "#666666",
+		ModalInfo:          "#777777",
+		Attention:          "#888888",
+	})
+
+	require.True(t, themeConfigured)
+	require.Equal(t, "#111111", HighlightPrimaryHex)
+	require.Equal(t, "#222222", HighlightSecondaryHex)
+	require.Equal(t, "#333333", StandardColorHex)
+	require.Equal(t, "#444444", ColorActiveHex)
+	require.Equal(t, "#555555", ColorWhiteHex)
+	require.Equal(t, "#666666", ColorLightGreyHex)
+	require.Equal(t, "#777777", ColorModalInfoHex)
+	require.Equal(t, "#888888", ColorAttentionHex)
+	require.Equal(t, tcell.GetColor("#202428"), TcellBackgroundColor)
+	require.Equal(t, "[#333333]", StandardColorTag)
+}
+
+func TestApplyTheme_NormalizesHexColors(t *testing.T) {
+	ApplyTheme(config.ThemeConfig{Standard: "333333"})
+
+	require.Equal(t, "#333333", StandardColorHex)
+	require.Equal(t, "[#333333]", StandardColorTag)
+}


### PR DESCRIPTION
Adds a `theme` block to the config.yml, to allow for custom colors. Defaults/unconfigured retain current defaults and result in no change. 

Defaults:
<img width="1511" height="632" alt="image" src="https://github.com/user-attachments/assets/d974bc72-525b-4831-8b2d-7faef423ce49" />

Custom theme: (gruvbox-dark-hard)
<img width="1514" height="630" alt="image" src="https://github.com/user-attachments/assets/37104e00-aa83-4329-86cb-51508a7f7103" />
