### PR TITLE
feat: recursive search across nested KV paths (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Recursive search** (`ctrl-f` in the secrets browser, [#30](https://github.com/dkyanakiev/vaul7y/issues/30)) — recursively walks all nested paths below the current one and matches secret names and key names (case-insensitive substring). In the results view, `v` re-runs the search matching secret *values* too, and `enter` jumps straight to a matching secret. Paths the token cannot list and secrets it cannot read are skipped and counted in the title bar instead of failing the search. Results stream in live, are capped at 200 matches, and requests are bounded to 5 concurrent calls to avoid hammering the Vault server.
+
 ## [0.2.0] - 2026-05-11
 
 ### Added

--- a/cmd/vaul7y/main.go
+++ b/cmd/vaul7y/main.go
@@ -70,6 +70,7 @@ func main() {
 	policies := component.NewPolicyTable()
 	policyAcl := component.NewPolicyAclTable()
 	secrets := component.NewSecretsTable()
+	searchResults := component.NewSearchResultsTable()
 	secretObj := component.NewSecretObjTable()
 	logo := component.NewLogo(version)
 	info := component.NewInfo()
@@ -85,8 +86,9 @@ func main() {
 		MountsTable:    mounts,
 		PolicyTable:    policies,
 		PolicyAclTable: policyAcl,
-		SecretsTable:   secrets,
-		SecretObjTable: secretObj,
+		SecretsTable:       secrets,
+		SearchResultsTable: searchResults,
+		SecretObjTable:     secretObj,
 		AuthTable:      authTable,
 		Info:           info,
 		Error:          errorComp,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,6 +92,17 @@ Variables will be loaded in the following order, with the next superseding the p
 * Filter paths and secrets with `/`
 * Jump directly to a path with `J`
 * Create new secrets with `ctrl-n` — choose JSON editor or Key-Value form
+* Recursive search with `ctrl-f` — searches secret names and key names in all nested paths below the current one
+
+#### Recursive search results
+
+`ctrl-f` prompts for a term and recursively walks every path under the current one, matching secret names and key names (case-insensitive). Folders you cannot list and secrets you cannot read are skipped and reported in the title bar — a token with partial access still gets results for everything it can see.
+
+| Key | Action |
+|-----|--------|
+| `e` / `enter` | Open the selected secret |
+| `v` | Toggle matching secret *values* too (re-runs the search) |
+| `b` / `esc` | Back to the secrets browser |
 
 #### Secret Object view
 

--- a/internal/models/search.go
+++ b/internal/models/search.go
@@ -1,0 +1,46 @@
+package models
+
+// SearchMatchType describes what part of a secret matched a recursive search.
+const (
+	SearchMatchPath  = "path"
+	SearchMatchKey   = "key"
+	SearchMatchValue = "value"
+)
+
+// SearchOptions configures a recursive KV search.
+type SearchOptions struct {
+	Mount string
+	// Path is the sub-path within the mount to start from ("" = mount root).
+	Path string
+	Term string
+	// MatchKeys matches key names inside secrets (requires read access).
+	MatchKeys bool
+	// MatchValues matches values inside secrets (requires read access).
+	MatchValues bool
+	// Concurrency bounds parallel Vault requests (default 5).
+	Concurrency int
+	// MaxResults stops the search early once reached (default 200).
+	MaxResults int
+}
+
+// SearchMatch is a single recursive search hit.
+type SearchMatch struct {
+	// Path of the secret within the mount (no mount prefix).
+	Path string
+	// Key that matched; empty for path matches.
+	Key string
+	// Type is one of SearchMatchPath, SearchMatchKey, SearchMatchValue.
+	Type string
+}
+
+// SearchStats summarizes a finished (or aborted) recursive search.
+type SearchStats struct {
+	SecretsScanned int
+	Matches        int
+	// ListDenied counts folders that could not be listed (no access or error).
+	ListDenied int
+	// ReadDenied counts secrets that could not be read (no access or error).
+	ReadDenied int
+	// Truncated is true when the search stopped at MaxResults.
+	Truncated bool
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -38,6 +38,14 @@ type State struct {
 	SealStatus    string
 	ClusterName   string
 
+	SearchResults       []models.SearchMatch
+	SearchStats         models.SearchStats
+	SearchTerm          string
+	SearchRunning       bool
+	SearchIncludeValues bool
+	// SearchBasePath is the path the search was started from, restored on esc.
+	SearchBasePath string
+
 	Elements *Elements
 	Toggle   *Toggle
 	Filter   *Filter
@@ -45,10 +53,11 @@ type State struct {
 }
 
 type Toggle struct {
-	Search       bool
-	JumpToPolicy bool
-	JumpToPath   bool
-	TextInput    bool
+	Search          bool
+	JumpToPolicy    bool
+	JumpToPath      bool
+	TextInput       bool
+	RecursiveSearch bool
 }
 
 type Filter struct {

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -64,6 +64,7 @@ func (v *Vault) kvVersionForMount(mount string) string {
 //go:generate counterfeiter . Logical
 type Logical interface {
 	List(path string) (*api.Secret, error)
+	Read(path string) (*api.Secret, error)
 }
 
 type Secret interface {

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -1,0 +1,244 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/dkyanakiev/vaul7y/internal/models"
+)
+
+const (
+	defaultSearchConcurrency = 5
+	defaultSearchMaxResults  = 200
+)
+
+// searchRun holds the shared state of one recursive search. All mutations go
+// through the mutex so onMatch is never called concurrently.
+type searchRun struct {
+	mu      sync.Mutex
+	stats   models.SearchStats
+	onMatch func(models.SearchMatch)
+	cancel  context.CancelFunc
+	max     int
+}
+
+func (r *searchRun) emit(m models.SearchMatch) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stats.Truncated {
+		return
+	}
+	r.stats.Matches++
+	r.onMatch(m)
+	if r.stats.Matches >= r.max {
+		r.stats.Truncated = true
+		r.cancel()
+	}
+}
+
+// SearchKV recursively walks a KV mount starting at opts.Path and reports
+// every match through onMatch. Secret names always match; key names and
+// values match when opts.MatchKeys / opts.MatchValues are set (both require
+// read access to each secret).
+//
+// Folders that cannot be listed and secrets that cannot be read are skipped
+// and counted in the returned stats — a token with partial access still gets
+// results for everything it can see.
+func (v *Vault) SearchKV(ctx context.Context, opts models.SearchOptions, onMatch func(models.SearchMatch)) (models.SearchStats, error) {
+	if opts.Term == "" {
+		return models.SearchStats{}, fmt.Errorf("empty search term")
+	}
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = defaultSearchConcurrency
+	}
+	if opts.MaxResults <= 0 {
+		opts.MaxResults = defaultSearchMaxResults
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	run := &searchRun{
+		onMatch: onMatch,
+		cancel:  cancel,
+		max:     opts.MaxResults,
+	}
+
+	kv2 := v.kvVersionForMount(opts.Mount) == "2"
+	term := strings.ToLower(opts.Term)
+	sem := make(chan struct{}, opts.Concurrency)
+
+	basePath := strings.TrimPrefix(opts.Path, "/")
+	if basePath != "" && !strings.HasSuffix(basePath, "/") {
+		basePath += "/"
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go v.searchWalk(ctx, &wg, sem, run, opts, kv2, term, basePath)
+	wg.Wait()
+
+	run.mu.Lock()
+	stats := run.stats
+	run.mu.Unlock()
+
+	// Hitting MaxResults cancels the internal context to stop the walkers;
+	// that is a successful (truncated) search, not an error.
+	err := ctx.Err()
+	if stats.Truncated {
+		err = nil
+	}
+	return stats, err
+}
+
+// searchWalk lists one folder, matches and reads its leaf secrets, and
+// spawns a goroutine per sub-folder.
+func (v *Vault) searchWalk(ctx context.Context, wg *sync.WaitGroup, sem chan struct{}, run *searchRun, opts models.SearchOptions, kv2 bool, term, sub string) {
+	defer wg.Done()
+
+	listPath := sanitizePath(fmt.Sprintf("%s/%s", opts.Mount, sub))
+	if kv2 {
+		listPath = sanitizePath(fmt.Sprintf("%s/metadata/%s", opts.Mount, sub))
+	}
+
+	if !acquire(ctx, sem) {
+		return
+	}
+	list, err := v.Logical.List(listPath)
+	release(sem)
+
+	if err != nil {
+		v.Logger.Debug().Err(err).Msgf("search: skipping unlistable path: %s", listPath)
+		run.mu.Lock()
+		run.stats.ListDenied++
+		run.mu.Unlock()
+		return
+	}
+
+	keys, ok := extractListData(list)
+	if !ok {
+		return
+	}
+
+	for _, k := range keys {
+		if ctx.Err() != nil {
+			return
+		}
+
+		entry, ok := k.(string)
+		if !ok {
+			continue
+		}
+		fullPath := sub + entry
+
+		if strings.HasSuffix(entry, "/") {
+			wg.Add(1)
+			go v.searchWalk(ctx, wg, sem, run, opts, kv2, term, fullPath)
+			continue
+		}
+
+		if strings.Contains(strings.ToLower(entry), term) {
+			run.emit(models.SearchMatch{Path: fullPath, Type: models.SearchMatchPath})
+		}
+
+		if opts.MatchKeys || opts.MatchValues {
+			v.searchReadSecret(ctx, sem, run, opts, kv2, term, fullPath)
+		}
+	}
+}
+
+// searchReadSecret reads one secret and matches its keys and/or values.
+func (v *Vault) searchReadSecret(ctx context.Context, sem chan struct{}, run *searchRun, opts models.SearchOptions, kv2 bool, term, fullPath string) {
+	readPath := sanitizePath(fmt.Sprintf("%s/%s", opts.Mount, fullPath))
+	if kv2 {
+		readPath = sanitizePath(fmt.Sprintf("%s/data/%s", opts.Mount, fullPath))
+	}
+
+	if !acquire(ctx, sem) {
+		return
+	}
+	secret, err := v.Logical.Read(readPath)
+	release(sem)
+
+	if err != nil {
+		v.Logger.Debug().Err(err).Msgf("search: skipping unreadable secret: %s", readPath)
+		run.mu.Lock()
+		run.stats.ReadDenied++
+		run.mu.Unlock()
+		return
+	}
+	if secret == nil || secret.Data == nil {
+		// Deleted or empty version — nothing to match.
+		return
+	}
+
+	data := secret.Data
+	if kv2 {
+		nested, ok := secret.Data["data"].(map[string]interface{})
+		if !ok {
+			// Soft-deleted current version: data is nil but metadata remains.
+			return
+		}
+		data = nested
+	}
+
+	run.mu.Lock()
+	run.stats.SecretsScanned++
+	run.mu.Unlock()
+
+	matchSecretData(run, opts, term, fullPath, data)
+}
+
+// matchSecretData walks a secret's data map (including nested maps) matching
+// key names and stringified values against the term.
+func matchSecretData(run *searchRun, opts models.SearchOptions, term, fullPath string, data map[string]interface{}) {
+	for key, value := range data {
+		if opts.MatchKeys && strings.Contains(strings.ToLower(key), term) {
+			run.emit(models.SearchMatch{Path: fullPath, Key: key, Type: models.SearchMatchKey})
+			continue
+		}
+
+		if nested, ok := value.(map[string]interface{}); ok {
+			matchSecretData(run, opts, term, fullPath, nested)
+			continue
+		}
+
+		if opts.MatchValues && strings.Contains(strings.ToLower(stringifyValue(value)), term) {
+			run.emit(models.SearchMatch{Path: fullPath, Key: key, Type: models.SearchMatchValue})
+		}
+	}
+}
+
+func stringifyValue(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case json.Number:
+		return v.String()
+	case bool:
+		return strconv.FormatBool(v)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// acquire takes a slot on the semaphore, giving up when the context is
+// cancelled. Returns false if the caller should abort.
+func acquire(ctx context.Context, sem chan struct{}) bool {
+	select {
+	case sem <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func release(sem chan struct{}) {
+	<-sem
+}

--- a/internal/vault/search_test.go
+++ b/internal/vault/search_test.go
@@ -1,0 +1,252 @@
+package vault_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/internal/vault"
+	"github.com/dkyanakiev/vaul7y/internal/vault/vaultfakes"
+	"github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/require"
+)
+
+func listSecret(keys ...interface{}) *api.Secret {
+	return &api.Secret{Data: map[string]interface{}{"keys": keys}}
+}
+
+func kv2Secret(data map[string]interface{}) *api.Secret {
+	return &api.Secret{Data: map[string]interface{}{"data": data}}
+}
+
+// fakeSearchTree wires a FakeLogical with this layout (KV v2 paths):
+//
+//	secret/
+//	├── top-token                   {token: abc}
+//	├── app/
+//	│   ├── db-creds                {db_password: hunter2, note: "token here"}
+//	│   ├── locked                  read → permission denied
+//	│   └── denied-dir/             list → permission denied
+func fakeSearchTree() *vaultfakes.FakeLogical {
+	fakeLogical := &vaultfakes.FakeLogical{}
+
+	fakeLogical.ListStub = func(path string) (*api.Secret, error) {
+		switch path {
+		case "secret/metadata":
+			return listSecret("app/", "top-token"), nil
+		case "secret/metadata/app":
+			return listSecret("db-creds", "locked", "denied-dir/"), nil
+		case "secret/metadata/app/denied-dir":
+			return nil, errors.New("permission denied")
+		}
+		return nil, nil
+	}
+
+	fakeLogical.ReadStub = func(path string) (*api.Secret, error) {
+		switch path {
+		case "secret/data/top-token":
+			return kv2Secret(map[string]interface{}{"token": "abc"}), nil
+		case "secret/data/app/db-creds":
+			return kv2Secret(map[string]interface{}{"db_password": "hunter2", "note": "token here"}), nil
+		case "secret/data/app/locked":
+			return nil, errors.New("permission denied")
+		}
+		return nil, nil
+	}
+
+	return fakeLogical
+}
+
+func collectMatches() (func(models.SearchMatch), *[]models.SearchMatch) {
+	var mu sync.Mutex
+	matches := &[]models.SearchMatch{}
+	return func(m models.SearchMatch) {
+		mu.Lock()
+		defer mu.Unlock()
+		*matches = append(*matches, m)
+	}, matches
+}
+
+func sortedMatches(matches []models.SearchMatch) []models.SearchMatch {
+	sorted := append([]models.SearchMatch{}, matches...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Path != sorted[j].Path {
+			return sorted[i].Path < sorted[j].Path
+		}
+		return sorted[i].Type < sorted[j].Type
+	})
+	return sorted
+}
+
+func TestSearchKV_KeysAndPaths(t *testing.T) {
+	v := &vault.Vault{
+		Logical: fakeSearchTree(),
+		Logger:  discardLogger(),
+	}
+
+	onMatch, matches := collectMatches()
+	stats, err := v.SearchKV(context.Background(), models.SearchOptions{
+		Mount:     "secret",
+		Term:      "TOKEN",
+		MatchKeys: true,
+	}, onMatch)
+
+	require.NoError(t, err)
+	require.Equal(t, []models.SearchMatch{
+		{Path: "top-token", Key: "token", Type: models.SearchMatchKey},
+		{Path: "top-token", Key: "", Type: models.SearchMatchPath},
+	}, sortedMatches(*matches))
+
+	require.Equal(t, 2, stats.Matches)
+	require.Equal(t, 2, stats.SecretsScanned)
+	require.Equal(t, 1, stats.ListDenied, "denied-dir list failure should be counted, not fatal")
+	require.Equal(t, 1, stats.ReadDenied, "locked read failure should be counted, not fatal")
+	require.False(t, stats.Truncated)
+}
+
+func TestSearchKV_Values(t *testing.T) {
+	v := &vault.Vault{
+		Logical: fakeSearchTree(),
+		Logger:  discardLogger(),
+	}
+
+	onMatch, matches := collectMatches()
+	stats, err := v.SearchKV(context.Background(), models.SearchOptions{
+		Mount:       "secret",
+		Term:        "token",
+		MatchKeys:   true,
+		MatchValues: true,
+	}, onMatch)
+
+	require.NoError(t, err)
+	require.Equal(t, []models.SearchMatch{
+		{Path: "app/db-creds", Key: "note", Type: models.SearchMatchValue},
+		{Path: "top-token", Key: "token", Type: models.SearchMatchKey},
+		{Path: "top-token", Key: "", Type: models.SearchMatchPath},
+	}, sortedMatches(*matches))
+	require.Equal(t, 3, stats.Matches)
+}
+
+func TestSearchKV_ValuesOff(t *testing.T) {
+	v := &vault.Vault{
+		Logical: fakeSearchTree(),
+		Logger:  discardLogger(),
+	}
+
+	onMatch, matches := collectMatches()
+	_, err := v.SearchKV(context.Background(), models.SearchOptions{
+		Mount:     "secret",
+		Term:      "hunter2",
+		MatchKeys: true,
+	}, onMatch)
+
+	require.NoError(t, err)
+	require.Empty(t, *matches, "values must not match when MatchValues is off")
+}
+
+func TestSearchKV_NestedData(t *testing.T) {
+	fakeLogical := &vaultfakes.FakeLogical{}
+	fakeLogical.ListStub = func(path string) (*api.Secret, error) {
+		if path == "secret/metadata" {
+			return listSecret("nested"), nil
+		}
+		return nil, nil
+	}
+	fakeLogical.ReadReturns(kv2Secret(map[string]interface{}{
+		"outer": map[string]interface{}{"inner_token": true},
+	}), nil)
+
+	v := &vault.Vault{
+		Logical: fakeLogical,
+		Logger:  discardLogger(),
+	}
+
+	onMatch, matches := collectMatches()
+	_, err := v.SearchKV(context.Background(), models.SearchOptions{
+		Mount:     "secret",
+		Term:      "inner_token",
+		MatchKeys: true,
+	}, onMatch)
+
+	require.NoError(t, err)
+	require.Equal(t, []models.SearchMatch{
+		{Path: "nested", Key: "inner_token", Type: models.SearchMatchKey},
+	}, *matches)
+}
+
+func TestSearchKV_Truncation(t *testing.T) {
+	v := &vault.Vault{
+		Logical: fakeSearchTree(),
+		Logger:  discardLogger(),
+	}
+
+	onMatch, matches := collectMatches()
+	stats, err := v.SearchKV(context.Background(), models.SearchOptions{
+		Mount:      "secret",
+		Term:       "token",
+		MatchKeys:  true,
+		MaxResults: 1,
+	}, onMatch)
+
+	require.NoError(t, err, "truncation is not an error")
+	require.True(t, stats.Truncated)
+	require.Len(t, *matches, 1)
+}
+
+func TestSearchKV_Cancelled(t *testing.T) {
+	v := &vault.Vault{
+		Logical: fakeSearchTree(),
+		Logger:  discardLogger(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	onMatch, matches := collectMatches()
+	_, err := v.SearchKV(ctx, models.SearchOptions{
+		Mount:     "secret",
+		Term:      "token",
+		MatchKeys: true,
+	}, onMatch)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, *matches)
+}
+
+func TestSearchKV_EmptyTerm(t *testing.T) {
+	v := &vault.Vault{
+		Logical: &vaultfakes.FakeLogical{},
+		Logger:  discardLogger(),
+	}
+
+	_, err := v.SearchKV(context.Background(), models.SearchOptions{Mount: "secret"}, func(models.SearchMatch) {})
+	require.Error(t, err)
+}
+
+func TestSearchKV_StartPath(t *testing.T) {
+	fakeLogical := fakeSearchTree()
+	v := &vault.Vault{
+		Logical: fakeLogical,
+		Logger:  discardLogger(),
+	}
+
+	onMatch, matches := collectMatches()
+	stats, err := v.SearchKV(context.Background(), models.SearchOptions{
+		Mount:     "secret",
+		Path:      "app/",
+		Term:      "db",
+		MatchKeys: true,
+	}, onMatch)
+
+	require.NoError(t, err)
+	require.Equal(t, []models.SearchMatch{
+		{Path: "app/db-creds", Key: "db_password", Type: models.SearchMatchKey},
+		{Path: "app/db-creds", Key: "", Type: models.SearchMatchPath},
+	}, sortedMatches(*matches))
+	require.Equal(t, 1, stats.ListDenied, "still counts list skips under the sub-tree")
+	require.Equal(t, 1, stats.ReadDenied, "still counts read skips under the sub-tree")
+	require.Equal(t, "secret/metadata/app", fakeLogical.ListArgsForCall(0), "search starts at the given sub-path")
+}

--- a/internal/vault/vaultfakes/fake_logical.go
+++ b/internal/vault/vaultfakes/fake_logical.go
@@ -22,6 +22,19 @@ type FakeLogical struct {
 		result1 *api.Secret
 		result2 error
 	}
+	ReadStub        func(string) (*api.Secret, error)
+	readMutex       sync.RWMutex
+	readArgsForCall []struct {
+		arg1 string
+	}
+	readReturns struct {
+		result1 *api.Secret
+		result2 error
+	}
+	readReturnsOnCall map[int]struct {
+		result1 *api.Secret
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -90,11 +103,77 @@ func (fake *FakeLogical) ListReturnsOnCall(i int, result1 *api.Secret, result2 e
 	}{result1, result2}
 }
 
+func (fake *FakeLogical) Read(arg1 string) (*api.Secret, error) {
+	fake.readMutex.Lock()
+	ret, specificReturn := fake.readReturnsOnCall[len(fake.readArgsForCall)]
+	fake.readArgsForCall = append(fake.readArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ReadStub
+	fakeReturns := fake.readReturns
+	fake.recordInvocation("Read", []interface{}{arg1})
+	fake.readMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeLogical) ReadCallCount() int {
+	fake.readMutex.RLock()
+	defer fake.readMutex.RUnlock()
+	return len(fake.readArgsForCall)
+}
+
+func (fake *FakeLogical) ReadCalls(stub func(string) (*api.Secret, error)) {
+	fake.readMutex.Lock()
+	defer fake.readMutex.Unlock()
+	fake.ReadStub = stub
+}
+
+func (fake *FakeLogical) ReadArgsForCall(i int) string {
+	fake.readMutex.RLock()
+	defer fake.readMutex.RUnlock()
+	argsForCall := fake.readArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLogical) ReadReturns(result1 *api.Secret, result2 error) {
+	fake.readMutex.Lock()
+	defer fake.readMutex.Unlock()
+	fake.ReadStub = nil
+	fake.readReturns = struct {
+		result1 *api.Secret
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLogical) ReadReturnsOnCall(i int, result1 *api.Secret, result2 error) {
+	fake.readMutex.Lock()
+	defer fake.readMutex.Unlock()
+	fake.ReadStub = nil
+	if fake.readReturnsOnCall == nil {
+		fake.readReturnsOnCall = make(map[int]struct {
+			result1 *api.Secret
+			result2 error
+		})
+	}
+	fake.readReturnsOnCall[i] = struct {
+		result1 *api.Secret
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeLogical) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
+	fake.readMutex.RLock()
+	defer fake.readMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/tui/component/commands.go
+++ b/tui/component/commands.go
@@ -51,6 +51,13 @@ var (
 		fmt.Sprintf("%sctrl-n%s to Create a new secret ", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%sJ%s to jump to a specific path", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s/%s Filter objects ", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sctrl-f%s recursive search from current path", styles.HighlightPrimaryTag, styles.StandardColorTag),
+	}
+	SearchResultsCommands = []string{
+		fmt.Sprintf("\n%s Search Results Commands:", styles.HighlightSecondaryTag),
+		fmt.Sprintf("%se or enter%s to open the selected secret", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sv%s toggle matching secret values (re-runs search)", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%sb or esc%s to go back to the secrets browser", styles.HighlightPrimaryTag, styles.StandardColorTag),
 	}
 	SecretObjectCommands = []string{
 		fmt.Sprintf("\n%s Secret Commands:", styles.HighlightSecondaryTag),

--- a/tui/component/constants.go
+++ b/tui/component/constants.go
@@ -12,4 +12,7 @@ const (
 	MountVersion     = "Version"
 	SecretPath       = "Path"
 	SecretObject     = "Secret Object"
+	SearchMatchPath  = "Path"
+	SearchMatchKey   = "Matched Key"
+	SearchMatchType  = "Matched On"
 )

--- a/tui/component/search_results_table.go
+++ b/tui/component/search_results_table.go
@@ -1,0 +1,124 @@
+package component
+
+import (
+	"fmt"
+
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	primitive "github.com/dkyanakiev/vaul7y/tui/primitives"
+	"github.com/dkyanakiev/vaul7y/tui/styles"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+var (
+	SearchResultsTableHeader = []string{
+		SearchMatchPath,
+		SearchMatchKey,
+		SearchMatchType,
+	}
+)
+
+type SearchResultsTable struct {
+	Table Table
+	Props *SearchResultsTableProps
+
+	slot *tview.Flex
+}
+
+type SearchResultsTableProps struct {
+	SelectedMount     string
+	Term              string
+	Running           bool
+	Stats             models.SearchStats
+	HandleNoResources models.HandlerFunc
+
+	Data []models.SearchMatch
+}
+
+func NewSearchResultsTable() *SearchResultsTable {
+	t := primitive.NewTable()
+
+	return &SearchResultsTable{
+		Table: t,
+		Props: &SearchResultsTableProps{},
+	}
+}
+
+func (s *SearchResultsTable) Bind(slot *tview.Flex) {
+	s.slot = slot
+}
+
+func (s *SearchResultsTable) reset() {
+	s.slot.Clear()
+	s.Table.Clear()
+}
+
+// GetPathForSelection returns the secret path of the currently selected row.
+func (s *SearchResultsTable) GetPathForSelection() string {
+	row, _ := s.Table.GetSelection()
+	return s.Table.GetCellContent(row, 0)
+}
+
+func (s *SearchResultsTable) Render() error {
+	s.reset()
+	s.Table.SetTitle("%s", s.titleText())
+
+	if len(s.Props.Data) == 0 {
+		if s.Props.Running {
+			s.Props.HandleNoResources(
+				"%ssearching…",
+				styles.HighlightPrimaryTag,
+			)
+		} else {
+			s.Props.HandleNoResources(
+				"%sno matches found\n¯%s\\_( ͡• ͜ʖ ͡•)_/¯",
+				styles.HighlightPrimaryTag,
+				styles.HighlightSecondaryTag,
+			)
+		}
+		return nil
+	}
+
+	s.Table.RenderHeader(SearchResultsTableHeader)
+	s.renderRows()
+
+	s.slot.AddItem(s.Table.Primitive(), 0, 1, false)
+	return nil
+}
+
+func (s *SearchResultsTable) titleText() string {
+	status := "done"
+	if s.Props.Running {
+		status = "searching…"
+	}
+
+	title := fmt.Sprintf("Search %q in %s — %d matches (%s)",
+		s.Props.Term, s.Props.SelectedMount, len(s.Props.Data), status)
+
+	skipped := s.Props.Stats.ListDenied + s.Props.Stats.ReadDenied
+	if skipped > 0 {
+		title += fmt.Sprintf(" — %d skipped (no access)", skipped)
+	}
+	if s.Props.Stats.Truncated {
+		title += " — result limit reached"
+	}
+	return title
+}
+
+func (s *SearchResultsTable) renderRows() {
+	for i, m := range s.Props.Data {
+		key := m.Key
+		if key == "" {
+			key = "-"
+		}
+		row := []string{
+			m.Path,
+			key,
+			m.Type,
+		}
+		index := i + 1
+		c := tcell.ColorYellow
+
+		s.Table.RenderRow(row, index, c)
+	}
+}

--- a/tui/view/init.go
+++ b/tui/view/init.go
@@ -52,6 +52,10 @@ func (v *View) Init(version string) {
 	v.components.SecretsTable.Bind(v.Layout.Body)
 	v.components.SecretsTable.Props.HandleNoResources = v.handleNoResources
 
+	// SearchResultsView
+	v.components.SearchResultsTable.Bind(v.Layout.Body)
+	v.components.SearchResultsTable.Props.HandleNoResources = v.handleNoResources
+
 	// SecretObjectView
 	v.components.SecretObjTable.Bind(v.Layout.Body)
 	v.components.SecretObjTable.Props.HandleNoResources = v.handleNoResources
@@ -128,11 +132,19 @@ func (v *View) Init(version string) {
 
 		v.state.Lock()
 		jumpToPath := v.state.Toggle.JumpToPath
+		recursiveSearch := v.state.Toggle.RecursiveSearch
 		v.state.Toggle.TextInput = false
 		v.state.Toggle.JumpToPath = false
+		v.state.Toggle.RecursiveSearch = false
 		v.state.Unlock()
 
-		if jumpToPath {
+		if recursiveSearch {
+			// Restore the label for the ctrl-n / J flows that share this input.
+			v.components.TextInfoInput.InputField.SetLabel("name: ")
+			if key == tcell.KeyEnter && inputText != "" {
+				v.startRecursiveSearch(inputText)
+			}
+		} else if jumpToPath {
 			v.state.Lock()
 			v.state.SelectedPath = inputText
 			v.state.Unlock()

--- a/tui/view/inputs.go
+++ b/tui/view/inputs.go
@@ -28,6 +28,11 @@ func (v *View) InputSecrets(event *tcell.EventKey) *tcell.EventKey {
 	return v.inputSecrets(event)
 }
 
+func (v *View) InputSearchResults(event *tcell.EventKey) *tcell.EventKey {
+	event = v.InputMainCommands(event)
+	return v.inputSearchResults(event)
+}
+
 func (v *View) InputSecret(event *tcell.EventKey) *tcell.EventKey {
 	event = v.InputMainCommands(event)
 	return v.inputSecret(event)

--- a/tui/view/searchresults.go
+++ b/tui/view/searchresults.go
@@ -1,0 +1,187 @@
+package view
+
+import (
+	"context"
+	"time"
+
+	"github.com/dkyanakiev/vaul7y/internal/models"
+	"github.com/dkyanakiev/vaul7y/tui/component"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const searchRefreshInterval = 300 * time.Millisecond
+
+// startRecursiveSearch kicks off a recursive KV search from the current path
+// and switches to the results view. Results stream in as the walker finds
+// them; folders and secrets the token cannot access are skipped and counted.
+func (v *View) startRecursiveSearch(term string) {
+	v.state.Lock()
+	v.state.SearchTerm = term
+	v.state.SearchResults = nil
+	v.state.SearchStats = models.SearchStats{}
+	v.state.SearchRunning = true
+	v.state.SearchBasePath = v.state.SelectedPath
+	mount := v.state.SelectedMount
+	basePath := v.state.SelectedPath
+	includeValues := v.state.SearchIncludeValues
+	v.state.Unlock()
+
+	// Switches the view first: its viewSwitch() cancels any previous search,
+	// so the context for this run must be created after it.
+	v.SearchResults()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	v.searchCancel = cancel
+
+	go func() {
+		opts := models.SearchOptions{
+			Mount:       mount,
+			Path:        basePath,
+			Term:        term,
+			MatchKeys:   true,
+			MatchValues: includeValues,
+		}
+
+		stats, err := v.Client.SearchKV(ctx, opts, func(m models.SearchMatch) {
+			v.state.Lock()
+			v.state.SearchResults = append(v.state.SearchResults, m)
+			v.state.Unlock()
+		})
+		if err != nil && ctx.Err() == nil {
+			v.logger.Warn().Err(err).Msg("recursive search failed")
+		}
+
+		v.state.Lock()
+		v.state.SearchStats = stats
+		v.state.SearchRunning = false
+		v.state.Unlock()
+
+		v.Layout.Container.QueueUpdateDraw(func() {
+			// The user may have navigated away while the search was running;
+			// don't draw the results table over another view.
+			if ctx.Err() != nil {
+				return
+			}
+			v.renderSearchResults()
+		})
+	}()
+
+	// Re-render periodically while the search streams results in.
+	go func() {
+		ticker := time.NewTicker(searchRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				v.state.RLock()
+				running := v.state.SearchRunning
+				v.state.RUnlock()
+				if !running {
+					return
+				}
+				v.Layout.Container.QueueUpdateDraw(func() {
+					if ctx.Err() != nil {
+						return
+					}
+					v.renderSearchResults()
+				})
+			}
+		}
+	}()
+}
+
+func (v *View) SearchResults() {
+	v.viewSwitch()
+	v.Layout.Body.Clear()
+	v.Layout.Body.SetTitle("Search Results")
+	v.Layout.Container.SetFocus(v.components.SearchResultsTable.Table.Primitive())
+	v.Layout.Container.SetInputCapture(v.InputSearchResults)
+	v.components.Commands.Update(component.SearchResultsCommands)
+
+	v.renderSearchResults()
+
+	v.state.Elements.TableMain = v.components.SearchResultsTable.Table.Primitive().(*tview.Table)
+}
+
+func (v *View) renderSearchResults() {
+	v.state.RLock()
+	data := append([]models.SearchMatch{}, v.state.SearchResults...)
+	term := v.state.SearchTerm
+	running := v.state.SearchRunning
+	stats := v.state.SearchStats
+	mount := v.state.SelectedMount
+	v.state.RUnlock()
+
+	t := v.components.SearchResultsTable
+	t.Props.Data = data
+	t.Props.Term = term
+	t.Props.Running = running
+	t.Props.Stats = stats
+	t.Props.SelectedMount = mount
+	t.Render()
+	v.Draw()
+}
+
+func (v *View) inputSearchResults(event *tcell.EventKey) *tcell.EventKey {
+	if event == nil {
+		return event
+	}
+
+	switch event.Key() {
+	case tcell.KeyEsc:
+		v.searchResultsGoBack()
+		return nil
+	case tcell.KeyEnter:
+		v.openSearchResult()
+		return nil
+	case tcell.KeyRune:
+		switch event.Rune() {
+		case 'e':
+			v.openSearchResult()
+			return nil
+		case 'b':
+			v.searchResultsGoBack()
+			return nil
+		case 'v':
+			v.state.Lock()
+			v.state.SearchIncludeValues = !v.state.SearchIncludeValues
+			term := v.state.SearchTerm
+			v.state.Unlock()
+			v.startRecursiveSearch(term)
+			return nil
+		}
+	}
+
+	return event
+}
+
+// openSearchResult navigates to the secret of the selected match.
+func (v *View) openSearchResult() {
+	path := v.components.SearchResultsTable.GetPathForSelection()
+	if path == "" {
+		return
+	}
+
+	v.state.Lock()
+	v.state.SelectedPath = path
+	mount := v.state.SelectedMount
+	v.state.Unlock()
+
+	v.SecretObject(mount, path)
+}
+
+// searchResultsGoBack returns to the secrets browser at the path the search
+// was started from.
+func (v *View) searchResultsGoBack() {
+	v.state.Lock()
+	base := v.state.SearchBasePath
+	v.state.SelectedPath = base
+	v.state.SelectedObject = ""
+	v.state.Unlock()
+
+	v.components.SecretsTable.Props.SelectedPath = base
+	v.Secrets(base, "false")
+}

--- a/tui/view/secrets.go
+++ b/tui/view/secrets.go
@@ -114,6 +114,24 @@ func (v *View) inputSecrets(event *tcell.EventKey) *tcell.EventKey {
 			}
 			return nil
 		}
+	case tcell.KeyCtrlF:
+		if !v.Layout.Footer.HasFocus() {
+			v.state.RLock()
+			textInput := v.state.Toggle.TextInput
+			v.state.RUnlock()
+			if !textInput {
+				v.state.Lock()
+				v.state.Toggle.TextInput = true
+				v.state.Toggle.RecursiveSearch = true
+				v.state.Unlock()
+				v.components.TextInfoInput.InputField.SetLabel("search: ")
+				v.components.TextInfoInput.InputField.SetText("")
+				v.TextInput()
+			} else {
+				v.Layout.Container.SetFocus(v.components.TextInfoInput.InputField.Primitive())
+			}
+			return nil
+		}
 	case tcell.KeyCtrlN:
 		v.logger.Debug().Msgf("Running New Secret view with : %v", v.state.SelectedPath)
 		if !v.Layout.Footer.HasFocus() {

--- a/tui/view/view.go
+++ b/tui/view/view.go
@@ -1,6 +1,7 @@
 package view
 
 import (
+	"context"
 	"sync"
 
 	"github.com/dkyanakiev/vaul7y/internal/models"
@@ -28,6 +29,7 @@ type Client interface {
 	ListAuthMethods() (map[string]*models.AuthMethod, error)
 	TokenInfo() (ttl int64, policies []string, err error)
 	SealStatus() (status string, clusterName string, err error)
+	SearchKV(ctx context.Context, opts models.SearchOptions, onMatch func(models.SearchMatch)) (models.SearchStats, error)
 }
 
 type Watcher interface {
@@ -57,16 +59,21 @@ type View struct {
 
 	FilterText string ""
 
+	// searchCancel stops a running recursive search; only touched from the
+	// UI event loop.
+	searchCancel context.CancelFunc
+
 	draw     chan struct{}
 	drawStop chan struct{}
 }
 
 type Components struct {
-	MountsTable    *component.MountsTable
-	PolicyTable    *component.PolicyTable
-	PolicyAclTable *component.PolicyAclTable
-	SecretsTable   *component.SecretsTable
-	SecretObjTable *component.SecretObjTable
+	MountsTable        *component.MountsTable
+	PolicyTable        *component.PolicyTable
+	PolicyAclTable     *component.PolicyAclTable
+	SecretsTable       *component.SecretsTable
+	SearchResultsTable *component.SearchResultsTable
+	SecretObjTable     *component.SecretObjTable
 	NamespaceTable *component.NamespaceTable
 	AuthTable      *component.AuthTable
 	Commands       *component.Commands
@@ -156,6 +163,14 @@ func (v *View) viewSwitch() {
 	v.Watcher.Unsubscribe()
 	v.resetSearch()
 	v.resetTextInput()
+	v.cancelRecursiveSearch()
+}
+
+func (v *View) cancelRecursiveSearch() {
+	if v.searchCancel != nil {
+		v.searchCancel()
+		v.searchCancel = nil
+	}
 }
 
 func (v *View) Search() {


### PR DESCRIPTION
ctrl-f in the secrets browser recursively walks all paths below the current one, matching secret names and key names (case-insensitive). In the results view, v re-runs the search matching values too, and enter jumps straight to a matching secret.

Folders the token cannot list and secrets it cannot read are skipped and counted in the title bar instead of failing the search, so tokens with partial access still get results for everything they can see. Requests are bounded to 5 concurrent calls, results stream in live and are capped at 200 matches. Works on KV v1 and v2 mounts.